### PR TITLE
Change name of json target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 
 # Json (MIT)
 include(json)
-target_link_libraries(polysolve PUBLIC nlohmann::json)
+target_link_libraries(polysolve PUBLIC nlohmann_json::nlohmann_json)
 
 # CHOLMOD solver
 if(POLYSOLVE_WITH_CHOLMOD)

--- a/cmake/recipes/json.cmake
+++ b/cmake/recipes/json.cmake
@@ -11,11 +11,11 @@
 #
 
 # JSON MIT
-if(TARGET nlohmann::json)
+if(TARGET nlohmann_json::nlohmann_json)
     return()
 endif()
 
-message(STATUS "Third-party: creating target 'nlohmann::json'")
+message(STATUS "Third-party: creating target 'nlohmann_json::nlohmann_json'")
 
 # nlohmann_json is a big repo for a single header, so we just download the release archive
 set(NLOHMANNJSON_VERSION "v3.10.2")
@@ -29,7 +29,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(nlohmann_json)
 
 add_library(nlohmann_json INTERFACE)
-add_library(nlohmann::json ALIAS nlohmann_json)
+add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
 
 include(GNUInstallDirs)
 target_include_directories(nlohmann_json INTERFACE


### PR DESCRIPTION
The default ALIAS target created by upstream is `nlohmann_json::nlohmann_json`:
https://github.com/nlohmann/json/blob/f6acdbec2c99670cf932d83cd797f08662e0b564/CMakeLists.txt#L103

To avoid conflicts with other integration (e.g. Lagrange) let's align the target name on upstream default.