### PR TITLE
Update Hypre to the newest

### DIFF
--- a/cmake/recipes/hypre.cmake
+++ b/cmake/recipes/hypre.cmake
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
     hypre
     GIT_REPOSITORY https://github.com/hypre-space/hypre.git
-    GIT_TAG v2.15.1
+    GIT_TAG v2.25.0
     GIT_SHALLOW TRUE
 )
 


### PR DESCRIPTION
Only update Hypre to v2.25.0, cmake cannot work