### PR TITLE
fix un-initialization

### DIFF
--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -127,6 +127,8 @@ namespace polysolve::nonlinear
 
         f_delta_step_tol = solver_params["advanced"]["f_delta_step_tol"];
 
+        m_descent_strategy = 0;
+
         set_line_search(solver_params);
     }
 


### PR DESCRIPTION
Uninitialized variable found by valgrind.

`m_descent_strategy` is initialized at Solver.cpp line 170, inside `reset()`, but at line 165
```
int previous_strategy = m_descent_strategy;
```
It gets the uninitialized value from `m_descent_strategy` and will be used at line 326.