### PR TITLE
Implement RobustArmijo and refactor Armijo Line Search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(POLYSOLVE_LARGE_INDEX)
 endif()
 
 target_compile_definitions(polysolve_linear PRIVATE POLYSOLVE_LINEAR_SPEC="${PROJECT_SOURCE_DIR}/linear-solver-spec.json")
-target_compile_definitions(polysolve PRIVATE POLYSOLVE_NON_LINEAR_SPEC="${PROJECT_SOURCE_DIR}/non-linear-solver-spec.json")
+target_compile_definitions(polysolve PRIVATE POLYSOLVE_NON_LINEAR_SPEC="${PROJECT_SOURCE_DIR}/nonlinear-solver-spec.json")
 target_compile_definitions(polysolve_linear PUBLIC POLYSOLVE_JSON_SPEC_DIR="${PROJECT_SOURCE_DIR}")
 
 

--- a/nonlinear-solver-spec.json
+++ b/nonlinear-solver-spec.json
@@ -283,7 +283,7 @@
     },
     {
         "pointer": "/line_search/method",
-        "default": "Backtracking",
+        "default": "RobustArmijo",
         "type": "string",
         "options": [
             "Armijo",

--- a/nonlinear-solver-spec.json
+++ b/nonlinear-solver-spec.json
@@ -176,7 +176,8 @@
             "max_step_size_iter_final",
             "default_init_step_size",
             "step_ratio",
-            "Armijo"
+            "Armijo",
+            "RobustArmijo"
         ],
         "doc": "Settings for line-search in the nonlinear solver"
     },

--- a/nonlinear-solver-spec.json
+++ b/nonlinear-solver-spec.json
@@ -253,6 +253,22 @@
         "doc": "Armijo c parameter."
     },
     {
+        "pointer": "/line_search/RobustArmijo",
+        "default": null,
+        "type": "object",
+        "optional": [
+            "delta_relative_tolerance"
+        ],
+        "doc": "Options for RobustArmijo."
+    },
+    {
+        "pointer": "/line_search/RobustArmijo/delta_relative_tolerance",
+        "default": 0.1,
+        "type": "float",
+        "min_value": 0,
+        "doc": "Relative tolerance on E to switch to approximate."
+    },
+    {
         "pointer": "/box_constraints",
         "type": "object",
         "optional": [

--- a/nonlinear-solver-spec.json
+++ b/nonlinear-solver-spec.json
@@ -1,5 +1,4 @@
-[
-    {
+[{
         "pointer": "/",
         "default": null,
         "type": "object",
@@ -188,6 +187,7 @@
         "options": [
             "Armijo",
             "ArmijoAlt",
+            "RobustArmijo",
             "Backtracking",
             "MoreThuente",
             "None"
@@ -247,8 +247,9 @@
     },
     {
         "pointer": "/line_search/Armijo/c",
-        "default": 0.5,
+        "default": 1e-4,
         "type": "float",
+        "min_value": 0,
         "doc": "Armijo c parameter."
     },
     {

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -184,7 +184,7 @@ namespace polysolve::nonlinear
         const auto g_norm_tol = this->m_stop.gradNorm;
         this->m_stop.gradNorm = first_grad_norm_tol;
 
-        StopWatch stop_watch("non-linear solver", this->total_time, m_logger);
+        StopWatch stop_watch("nonlinear solver", this->total_time, m_logger);
         stop_watch.start();
 
         m_logger.debug(

--- a/src/polysolve/nonlinear/descent_strategies/Newton.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.hpp
@@ -104,7 +104,10 @@ namespace polysolve::nonlinear
                           const double characteristic_length,
                           spdlog::logger &logger);
 
-        std::string name() const override { return internal_name() + "RegularizedNewton"; }
+        std::string name() const override
+        {
+            return fmt::format("{}RegularizedNewton (reg_weight={:g})", internal_name(), reg_weight);
+        }
 
         void reset(const int ndof) override;
         bool handle_error() override;

--- a/src/polysolve/nonlinear/line_search/Armijo.cpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.cpp
@@ -19,11 +19,12 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool Armijo::criteria(
+        Problem &objFunc,
         const TVector &delta_x,
+        const TVector &new_x,
         const double old_energy,
         const TVector &old_grad,
         const double new_energy,
-        const TVector &new_grad,
         const double step_size) const
     {
         // TODO: Use use_grad_norm

--- a/src/polysolve/nonlinear/line_search/Armijo.cpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.cpp
@@ -19,15 +19,15 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool Armijo::criteria(
-        Problem &objFunc,
         const TVector &delta_x,
-        const TVector &new_x,
+        Problem &objFunc,
+        const bool use_grad_norm,
         const double old_energy,
         const TVector &old_grad,
+        const TVector &new_x,
         const double new_energy,
         const double step_size) const
     {
-        // TODO: Use use_grad_norm
         return new_energy <= old_energy + step_size * armijo_criteria;
     }
 

--- a/src/polysolve/nonlinear/line_search/Armijo.cpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.cpp
@@ -2,10 +2,6 @@
 
 #include "Armijo.hpp"
 
-#include <polysolve/Utils.hpp>
-
-#include <spdlog/spdlog.h>
-
 namespace polysolve::nonlinear::line_search
 {
     Armijo::Armijo(const json &params, spdlog::logger &logger)
@@ -14,58 +10,24 @@ namespace polysolve::nonlinear::line_search
         c = params["line_search"]["Armijo"]["c"];
     }
 
-    double Armijo::compute_descent_step_size(
-        const TVector &x,
-        const TVector &searchDir,
-        Problem &objFunc,
-        const bool use_grad_norm,
-        const double old_energy_in,
-        const double starting_step_size)
+    void Armijo::init_compute_descent_step_size(
+        const TVector &delta_x,
+        const TVector &old_grad)
     {
-        TVector grad(x.rows());
-        double f_in = old_energy_in;
-        double alpha = starting_step_size;
+        armijo_criteria = c * delta_x.dot(old_grad);
+        assert(armijo_criteria <= 0);
+    }
 
-        bool valid;
-
-        TVector x1 = x + alpha * searchDir;
-        {
-            POLYSOLVE_SCOPED_STOPWATCH("constraint set update in LS", constraint_set_update_time, m_logger);
-            objFunc.solution_changed(x1);
-        }
-
-        objFunc.gradient(x, grad);
-
-        double f = use_grad_norm ? grad.squaredNorm() : objFunc.value(x1);
-        const double cache = c * grad.dot(searchDir);
-        valid = objFunc.is_step_valid(x, x1);
-
-        while ((std::isinf(f) || std::isnan(f) || f > f_in + alpha * cache || !valid) && alpha > current_min_step_size() && cur_iter <= current_max_step_size_iter())
-        {
-            alpha *= step_ratio;
-            x1 = x + alpha * searchDir;
-
-            {
-                POLYSOLVE_SCOPED_STOPWATCH("constraint set update in LS", constraint_set_update_time, m_logger);
-                objFunc.solution_changed(x1);
-            }
-
-            if (use_grad_norm)
-            {
-                objFunc.gradient(x1, grad);
-                f = grad.squaredNorm();
-            }
-            else
-                f = objFunc.value(x1);
-
-            valid = objFunc.is_step_valid(x, x1);
-
-            m_logger.trace("ls it: {} f: {} (f_in + alpha * Cache): {} invalid: {} ", cur_iter, f, f_in + alpha * cache, !valid);
-
-            cur_iter++;
-        }
-
-        return alpha;
+    bool Armijo::criteria(
+        const TVector &delta_x,
+        const double old_energy,
+        const TVector &old_grad,
+        const double new_energy,
+        const TVector &new_grad,
+        const double step_size) const
+    {
+        // TODO: Use use_grad_norm
+        return new_energy <= old_energy + step_size * armijo_criteria;
     }
 
 }; // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/Armijo.hpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.hpp
@@ -21,11 +21,12 @@ namespace polysolve::nonlinear::line_search
             const TVector &old_grad) override;
 
         virtual bool criteria(
-            Problem &objFunc,
             const TVector &delta_x,
-            const TVector &new_x,
+            Problem &objFunc,
+            const bool use_grad_norm,
             const double old_energy,
             const TVector &old_grad,
+            const TVector &new_x,
             const double new_energy,
             const double step_size) const override;
 

--- a/src/polysolve/nonlinear/line_search/Armijo.hpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.hpp
@@ -21,11 +21,12 @@ namespace polysolve::nonlinear::line_search
             const TVector &old_grad) override;
 
         virtual bool criteria(
+            Problem &objFunc,
             const TVector &delta_x,
+            const TVector &new_x,
             const double old_energy,
             const TVector &old_grad,
             const double new_energy,
-            const TVector &new_grad,
             const double step_size) const override;
 
         double c;

--- a/src/polysolve/nonlinear/line_search/Armijo.hpp
+++ b/src/polysolve/nonlinear/line_search/Armijo.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "LineSearch.hpp"
+#include "Backtracking.hpp"
 
 namespace polysolve::nonlinear::line_search
 {
-    class Armijo : public LineSearch
+    class Armijo : public Backtracking
     {
     public:
-        using Superclass = LineSearch;
+        using Superclass = Backtracking;
         using typename Superclass::Scalar;
         using typename Superclass::TVector;
 
@@ -16,15 +16,19 @@ namespace polysolve::nonlinear::line_search
         virtual std::string name() override { return "Armijo"; }
 
     protected:
-        double compute_descent_step_size(
-            const TVector &x,
+        virtual void init_compute_descent_step_size(
             const TVector &delta_x,
-            Problem &objFunc,
-            const bool use_grad_norm,
-            const double old_energy_in,
-            const double starting_step_size) override;
+            const TVector &old_grad) override;
 
-    private:
+        virtual bool criteria(
+            const TVector &delta_x,
+            const double old_energy,
+            const TVector &old_grad,
+            const double new_energy,
+            const TVector &new_grad,
+            const double step_size) const override;
+
         double c;
+        double armijo_criteria; ///< cached value: c * delta_x.dot(old_grad)
     };
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/Backtracking.cpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.cpp
@@ -48,17 +48,14 @@ namespace polysolve::nonlinear::line_search
 
             const double new_energy = objFunc.value(new_x);
 
-            TVector new_grad; // TODO: only compute gradient if needed
-            objFunc.gradient(new_x, new_grad);
-
-            if (!std::isfinite(new_energy) || !std::isfinite(new_grad.norm()))
+            if (!std::isfinite(new_energy))
             {
                 continue;
             }
 
             m_logger.trace("ls it: {} ΔE: {}", cur_iter, new_energy - old_energy);
 
-            if (criteria(delta_x, old_energy, old_grad, new_energy, new_grad, step_size))
+            if (criteria(objFunc, delta_x, new_x, old_energy, old_grad, new_energy, step_size))
             {
                 break; // found a good step size
             }
@@ -68,11 +65,12 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool Backtracking::criteria(
+        Problem &objFunc,
         const TVector &delta_x,
+        const TVector &new_x,
         const double old_energy,
         const TVector &old_grad,
         const double new_energy,
-        const TVector &new_grad,
         const double step_size) const
     {
         return new_energy < old_energy;

--- a/src/polysolve/nonlinear/line_search/Backtracking.cpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.cpp
@@ -21,7 +21,6 @@ namespace polysolve::nonlinear::line_search
         const TVector &old_grad,
         const double starting_step_size)
     {
-        assert(!use_grad_norm);
         double step_size = starting_step_size;
 
         init_compute_descent_step_size(delta_x, old_grad);
@@ -55,7 +54,7 @@ namespace polysolve::nonlinear::line_search
 
             m_logger.trace("ls it: {} ΔE: {}", cur_iter, new_energy - old_energy);
 
-            if (criteria(objFunc, delta_x, new_x, old_energy, old_grad, new_energy, step_size))
+            if (criteria(delta_x, objFunc, use_grad_norm, old_energy, old_grad, new_x, new_energy, step_size))
             {
                 break; // found a good step size
             }
@@ -65,14 +64,21 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool Backtracking::criteria(
-        Problem &objFunc,
         const TVector &delta_x,
-        const TVector &new_x,
+        Problem &objFunc,
+        const bool use_grad_norm,
         const double old_energy,
         const TVector &old_grad,
+        const TVector &new_x,
         const double new_energy,
         const double step_size) const
     {
+        if (use_grad_norm)
+        {
+            TVector new_grad;
+            objFunc.gradient(new_x, new_grad);
+            return new_grad.norm() < old_grad.norm(); // TODO: cache old_grad.norm()
+        }
         return new_energy < old_energy;
     }
 

--- a/src/polysolve/nonlinear/line_search/Backtracking.cpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.cpp
@@ -33,7 +33,7 @@ namespace polysolve::nonlinear::line_search
             try
             {
                 POLYSOLVE_SCOPED_STOPWATCH("solution changed - constraint set update in LS", constraint_set_update_time, m_logger);
-                objFunc.solution_changed(x);
+                objFunc.solution_changed(new_x);
             }
             catch (const std::runtime_error &e)
             {

--- a/src/polysolve/nonlinear/line_search/Backtracking.cpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.cpp
@@ -4,8 +4,6 @@
 
 #include <spdlog/spdlog.h>
 
-#include <cfenv>
-
 namespace polysolve::nonlinear::line_search
 {
 
@@ -20,58 +18,64 @@ namespace polysolve::nonlinear::line_search
         Problem &objFunc,
         const bool use_grad_norm,
         const double old_energy,
+        const TVector &old_grad,
         const double starting_step_size)
     {
+        assert(!use_grad_norm);
         double step_size = starting_step_size;
 
-        TVector grad(x.rows());
+        init_compute_descent_step_size(delta_x, old_grad);
 
-        // Find step that reduces the energy
-        double cur_energy = std::nan("");
-        bool is_step_valid = false;
-        while (step_size > current_min_step_size() && cur_iter < current_max_step_size_iter())
+        for (; step_size > current_min_step_size() && cur_iter < current_max_step_size_iter(); step_size *= step_ratio, ++cur_iter)
         {
-            TVector new_x = x + step_size * delta_x;
+            const TVector new_x = x + step_size * delta_x;
 
             try
             {
-                POLYSOLVE_SCOPED_STOPWATCH("solution changed - constraint set update in LS", this->constraint_set_update_time, m_logger);
-                objFunc.solution_changed(new_x);
+                POLYSOLVE_SCOPED_STOPWATCH("solution changed - constraint set update in LS", constraint_set_update_time, m_logger);
+                objFunc.solution_changed(x);
             }
             catch (const std::runtime_error &e)
             {
                 m_logger.warn("Failed to take step due to \"{}\", reduce step size...", e.what());
-
-                step_size *= step_ratio;
-                this->cur_iter++;
                 continue;
             }
 
-            if (use_grad_norm)
+            if (!objFunc.is_step_valid(x, new_x))
             {
-                objFunc.gradient(new_x, grad);
-                cur_energy = grad.squaredNorm();
+                continue;
             }
-            else
-                cur_energy = objFunc.value(new_x);
 
-            is_step_valid = objFunc.is_step_valid(x, new_x);
+            const double new_energy = objFunc.value(new_x);
 
-            m_logger.trace("ls it: {} delta: {} invalid: {} ", this->cur_iter, (cur_energy - old_energy), !is_step_valid);
+            TVector new_grad; // TODO: only compute gradient if needed
+            objFunc.gradient(new_x, new_grad);
 
-            if (!std::isfinite(cur_energy) || cur_energy >= old_energy || !is_step_valid)
+            if (!std::isfinite(new_energy) || !std::isfinite(new_grad.norm()))
             {
-                step_size *= step_ratio;
-                // max_step_size should return a collision free step
-                // assert(objFunc.is_step_collision_free(x, new_x));
+                continue;
             }
-            else
+
+            m_logger.trace("ls it: {} ΔE: {}", cur_iter, new_energy - old_energy);
+
+            if (criteria(delta_x, old_energy, old_grad, new_energy, new_grad, step_size))
             {
-                break;
+                break; // found a good step size
             }
-            this->cur_iter++;
         }
 
         return step_size;
     }
+
+    bool Backtracking::criteria(
+        const TVector &delta_x,
+        const double old_energy,
+        const TVector &old_grad,
+        const double new_energy,
+        const TVector &new_grad,
+        const double step_size) const
+    {
+        return new_energy < old_energy;
+    }
+
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/Backtracking.hpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.hpp
@@ -15,13 +15,26 @@ namespace polysolve::nonlinear::line_search
 
         virtual std::string name() override { return "Backtracking"; }
 
-    public:
         double compute_descent_step_size(
             const TVector &x,
             const TVector &delta_x,
             Problem &objFunc,
             const bool use_grad_norm,
-            const double old_energy_in,
+            const double old_energy,
+            const TVector &old_grad,
             const double starting_step_size) override;
+
+    protected:
+        virtual void init_compute_descent_step_size(
+            const TVector &delta_x,
+            const TVector &old_grad) {}
+
+        virtual bool criteria(
+            const TVector &delta_x,
+            const double old_energy,
+            const TVector &old_grad,
+            const double new_energy,
+            const TVector &new_grad,
+            const double step_size) const;
     };
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/Backtracking.hpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.hpp
@@ -30,11 +30,12 @@ namespace polysolve::nonlinear::line_search
             const TVector &old_grad) {}
 
         virtual bool criteria(
+            Problem &objFunc,
             const TVector &delta_x,
+            const TVector &new_x,
             const double old_energy,
             const TVector &old_grad,
             const double new_energy,
-            const TVector &new_grad,
             const double step_size) const;
     };
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/Backtracking.hpp
+++ b/src/polysolve/nonlinear/line_search/Backtracking.hpp
@@ -30,11 +30,12 @@ namespace polysolve::nonlinear::line_search
             const TVector &old_grad) {}
 
         virtual bool criteria(
-            Problem &objFunc,
             const TVector &delta_x,
-            const TVector &new_x,
+            Problem &objFunc,
+            const bool use_grad_norm,
             const double old_energy,
             const TVector &old_grad,
+            const TVector &new_x,
             const double new_energy,
             const double step_size) const;
     };

--- a/src/polysolve/nonlinear/line_search/CMakeLists.txt
+++ b/src/polysolve/nonlinear/line_search/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
 	MoreThuente.hpp
 	NoLineSearch.cpp
 	NoLineSearch.hpp
+	RobustArmijo.cpp
+	RobustArmijo.hpp
 )
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" PREFIX "Source Files" FILES ${SOURCES})

--- a/src/polysolve/nonlinear/line_search/CppOptArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/CppOptArmijo.cpp
@@ -15,11 +15,12 @@ namespace polysolve::nonlinear::line_search
         Problem &objFunc,
         const bool use_grad_norm,
         const double old_energy,
+        const TVector &old_grad,
         const double starting_step_size)
     {
         double step_size = cppoptlib::Armijo<Problem, 1>::linesearch(x, delta_x, objFunc, starting_step_size);
         // this ensures no collisions and decrease in energy
-        return after_check.compute_descent_step_size(x, delta_x, objFunc, use_grad_norm, old_energy, step_size);
+        return after_check.compute_descent_step_size(x, delta_x, objFunc, use_grad_norm, old_energy, old_grad, step_size);
     }
 
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/CppOptArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/CppOptArmijo.hpp
@@ -23,6 +23,7 @@ namespace polysolve::nonlinear::line_search
             Problem &objFunc,
             const bool use_grad_norm,
             const double old_energy,
+            const TVector &old_grad,
             const double starting_step_size) override;
 
     private:

--- a/src/polysolve/nonlinear/line_search/LineSearch.cpp
+++ b/src/polysolve/nonlinear/line_search/LineSearch.cpp
@@ -150,7 +150,7 @@ namespace polysolve::nonlinear::line_search
             return step_size;
 
         // TODO: Fix this
-        const bool use_grad_norm = false; // initial_grad.norm() < use_grad_norm_tol;
+        const bool use_grad_norm = initial_grad.norm() < use_grad_norm_tol;
         const double starting_step_size = step_size;
 
         // ----------------------

--- a/src/polysolve/nonlinear/line_search/LineSearch.hpp
+++ b/src/polysolve/nonlinear/line_search/LineSearch.hpp
@@ -86,7 +86,8 @@ namespace polysolve::nonlinear::line_search
             const TVector &delta_x,
             Problem &objFunc,
             const bool use_grad_norm,
-            const double old_energy_in,
+            const double old_energy,
+            const TVector &old_grad,
             const double starting_step_size) = 0;
 
     private:

--- a/src/polysolve/nonlinear/line_search/MoreThuente.cpp
+++ b/src/polysolve/nonlinear/line_search/MoreThuente.cpp
@@ -15,10 +15,11 @@ namespace polysolve::nonlinear::line_search
         Problem &objFunc,
         const bool use_grad_norm,
         const double old_energy,
+        const TVector &old_grad,
         const double starting_step_size)
     {
         const double tmp = cppoptlib::MoreThuente<Problem, 1>::linesearch(x, delta_x, objFunc, starting_step_size);
         // this ensures no collisions and decrease in energy
-        return after_check.compute_descent_step_size(x, delta_x, objFunc, use_grad_norm, old_energy, std::min(tmp, starting_step_size));
+        return after_check.compute_descent_step_size(x, delta_x, objFunc, use_grad_norm, old_energy, old_grad, std::min(tmp, starting_step_size));
     }
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/MoreThuente.hpp
+++ b/src/polysolve/nonlinear/line_search/MoreThuente.hpp
@@ -23,6 +23,7 @@ namespace polysolve::nonlinear::line_search
             Problem &objFunc,
             const bool use_grad_norm,
             const double old_energy,
+            const TVector &old_grad,
             const double starting_step_size) override;
 
     private:

--- a/src/polysolve/nonlinear/line_search/NoLineSearch.cpp
+++ b/src/polysolve/nonlinear/line_search/NoLineSearch.cpp
@@ -13,6 +13,7 @@ namespace polysolve::nonlinear::line_search
         Problem &objFunc,
         const bool,
         const double,
+        const TVector &,
         const double starting_step_size)
     {
         objFunc.solution_changed(x + delta_x * starting_step_size);

--- a/src/polysolve/nonlinear/line_search/NoLineSearch.hpp
+++ b/src/polysolve/nonlinear/line_search/NoLineSearch.hpp
@@ -21,6 +21,7 @@ namespace polysolve::nonlinear::line_search
             Problem &objFunc,
             const bool,
             const double,
+            const TVector &,
             const double starting_step_size) override;
     };
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
@@ -9,6 +9,7 @@ namespace polysolve::nonlinear::line_search
     RobustArmijo::RobustArmijo(const json &params, spdlog::logger &logger)
         : Superclass(params, logger)
     {
+        delta_relative_tolerance = params.at("delta_relative_tolerance");
     }
 
     bool RobustArmijo::criteria(
@@ -22,7 +23,7 @@ namespace polysolve::nonlinear::line_search
         if (new_energy <= old_energy + step_size * this->armijo_criteria) // Try Armijo first
             return true;
 
-        if (std::abs(new_energy - old_energy) <= 0.1 * std::abs(old_energy))
+        if (std::abs(new_energy - old_energy) <= delta_relative_tolerance * std::abs(old_energy))
         {
             // TODO: Compute new_grad here as needed
             // objFunc.gradient(new_x, new_grad);

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
@@ -14,11 +14,12 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool RobustArmijo::criteria(
-        Problem &objFunc,
         const TVector &delta_x,
-        const TVector &new_x,
+        Problem &objFunc,
+        const bool use_grad_norm,
         const double old_energy,
         const TVector &old_grad,
+        const TVector &new_x,
         const double new_energy,
         const double step_size) const
     {

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
@@ -1,0 +1,41 @@
+#include "RobustArmijo.hpp"
+
+#include <polysolve/Utils.hpp>
+
+#include <spdlog/spdlog.h>
+
+namespace polysolve::nonlinear::line_search
+{
+    RobustArmijo::RobustArmijo(const json &params, spdlog::logger &logger)
+        : Superclass(params, logger)
+    {
+    }
+
+    bool RobustArmijo::criteria(
+        const TVector &delta_x,
+        const double old_energy,
+        const TVector &old_grad,
+        const double new_energy,
+        const TVector &new_grad,
+        const double step_size) const
+    {
+        if (new_energy <= old_energy + step_size * this->armijo_criteria) // Try Armijo first
+            return true;
+
+        if (std::abs(new_energy - old_energy) <= 0.1 * std::abs(old_energy))
+        {
+            // TODO: Compute new_grad here as needed
+            // objFunc.gradient(new_x, new_grad);
+            assert(old_grad.size() == new_grad.size());
+
+            const double deltaE_approx = step_size / 2 * delta_x.dot(new_grad + old_grad);
+            const double abs_eps_est = step_size / 2 * std::abs(delta_x.dot(new_grad - old_grad));
+
+            if (deltaE_approx + abs_eps_est <= step_size * this->armijo_criteria)
+                return true;
+        }
+
+        return false;
+    }
+
+}; // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
@@ -9,7 +9,8 @@ namespace polysolve::nonlinear::line_search
     RobustArmijo::RobustArmijo(const json &params, spdlog::logger &logger)
         : Superclass(params, logger)
     {
-        delta_relative_tolerance = params.at("delta_relative_tolerance");
+        delta_relative_tolerance = params.at(
+            "/line_search/RobustArmijo/delta_relative_tolerance"_json_pointer);
     }
 
     bool RobustArmijo::criteria(

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.cpp
@@ -14,11 +14,12 @@ namespace polysolve::nonlinear::line_search
     }
 
     bool RobustArmijo::criteria(
+        Problem &objFunc,
         const TVector &delta_x,
+        const TVector &new_x,
         const double old_energy,
         const TVector &old_grad,
         const double new_energy,
-        const TVector &new_grad,
         const double step_size) const
     {
         if (new_energy <= old_energy + step_size * this->armijo_criteria) // Try Armijo first
@@ -26,9 +27,8 @@ namespace polysolve::nonlinear::line_search
 
         if (std::abs(new_energy - old_energy) <= delta_relative_tolerance * std::abs(old_energy))
         {
-            // TODO: Compute new_grad here as needed
-            // objFunc.gradient(new_x, new_grad);
-            assert(old_grad.size() == new_grad.size());
+            TVector new_grad;
+            objFunc.gradient(new_x, new_grad);
 
             const double deltaE_approx = step_size / 2 * delta_x.dot(new_grad + old_grad);
             const double abs_eps_est = step_size / 2 * std::abs(delta_x.dot(new_grad - old_grad));

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
@@ -4,6 +4,7 @@
 
 namespace polysolve::nonlinear::line_search
 {
+    /// @brief Numerically robust Armijo line search algorithm of Longva et al. [2023]
     class RobustArmijo : public Armijo
     {
     public:

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
@@ -24,6 +24,8 @@ namespace polysolve::nonlinear::line_search
             const double new_energy,
             const TVector &new_grad,
             const double step_size) const override;
+
+        double delta_relative_tolerance;
     };
 
 } // namespace polysolve::nonlinear::line_search

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
@@ -18,11 +18,12 @@ namespace polysolve::nonlinear::line_search
 
     protected:
         bool criteria(
+            Problem &objFunc,
             const TVector &delta_x,
+            const TVector &new_x,
             const double old_energy,
             const TVector &old_grad,
             const double new_energy,
-            const TVector &new_grad,
             const double step_size) const override;
 
         double delta_relative_tolerance;

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
@@ -18,11 +18,12 @@ namespace polysolve::nonlinear::line_search
 
     protected:
         bool criteria(
-            Problem &objFunc,
             const TVector &delta_x,
-            const TVector &new_x,
+            Problem &objFunc,
+            const bool use_grad_norm,
             const double old_energy,
             const TVector &old_grad,
+            const TVector &new_x,
             const double new_energy,
             const double step_size) const override;
 

--- a/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
+++ b/src/polysolve/nonlinear/line_search/RobustArmijo.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Armijo.hpp"
+
+namespace polysolve::nonlinear::line_search
+{
+    class RobustArmijo : public Armijo
+    {
+    public:
+        using Superclass = Armijo;
+        using typename Superclass::Scalar;
+        using typename Superclass::TVector;
+
+        RobustArmijo(const json &params, spdlog::logger &logger);
+
+        virtual std::string name() override { return "RobustArmijo"; }
+
+    protected:
+        bool criteria(
+            const TVector &delta_x,
+            const double old_energy,
+            const TVector &old_grad,
+            const double new_energy,
+            const TVector &new_grad,
+            const double step_size) const override;
+    };
+
+} // namespace polysolve::nonlinear::line_search

--- a/tests/test_nonlinear_solver.cpp
+++ b/tests/test_nonlinear_solver.cpp
@@ -240,14 +240,18 @@ public:
     }
 };
 
-
 class InequalityConstraint : public Problem
 {
 public:
-    InequalityConstraint(const double upper_bound): upper_bound_(upper_bound) {}
+    InequalityConstraint(const double upper_bound) : upper_bound_(upper_bound) {}
     double value(const TVector &x) override { return x(0) - upper_bound_; }
-    void gradient(const TVector &x, TVector &gradv) override { gradv.setZero(x.size()); gradv(0) = 1; }
+    void gradient(const TVector &x, TVector &gradv) override
+    {
+        gradv.setZero(x.size());
+        gradv(0) = 1;
+    }
     void hessian(const TVector &x, THessian &hessian) override {}
+
 private:
     const double upper_bound_;
 };
@@ -351,18 +355,18 @@ void test_solvers(const std::vector<std::string> &solvers, const int iters, cons
     }
 }
 
-TEST_CASE("non-linear", "[solver]")
+TEST_CASE("nonlinear", "[solver]")
 {
     test_solvers(Solver::available_solvers(), 1000, false);
     // test_solvers({"L-BFGS"}, 1000, false);
 }
 
-TEST_CASE("non-linear-easier", "[solver]")
+TEST_CASE("nonlinear-easier", "[solver]")
 {
     test_solvers(Solver::available_solvers(), 5000, true);
 }
 
-TEST_CASE("non-linear-box-constraint", "[solver]")
+TEST_CASE("nonlinear-box-constraint", "[solver]")
 {
     std::vector<std::unique_ptr<TestProblem>> problems;
     problems.push_back(std::make_unique<QuadraticProblem>());
@@ -395,7 +399,7 @@ TEST_CASE("non-linear-box-constraint", "[solver]")
                 if (ls == "None" && solver_name != "MMA")
                     continue;
                 if (solver_name == "MMA" && ls != "None")
-                     continue;
+                    continue;
                 solver_params["line_search"]["method"] = ls;
 
                 auto solver = BoxConstraintSolver::create(solver_params,
@@ -434,7 +438,7 @@ TEST_CASE("non-linear-box-constraint", "[solver]")
     }
 }
 
-TEST_CASE("non-linear-box-constraint-input", "[solver]")
+TEST_CASE("nonlinear-box-constraint-input", "[solver]")
 {
     std::vector<std::unique_ptr<TestProblem>> problems;
     problems.push_back(std::make_unique<QuadraticProblem>());
@@ -461,7 +465,7 @@ TEST_CASE("non-linear-box-constraint-input", "[solver]")
                 if (ls == "None" && solver_name != "MMA")
                     continue;
                 if (solver_name == "MMA" && ls != "None")
-                     continue;
+                    continue;
                 solver_params["line_search"]["method"] = ls;
 
                 QuadraticProblem::TVector x(prob->size());
@@ -528,13 +532,11 @@ TEST_CASE("MMA", "[solver]")
         solver_params["solver"] = "MMA";
         solver_params["line_search"]["method"] = "None";
 
-        auto solver = BoxConstraintSolver::create(solver_params,
-                                                    linear_solver_params,
-                                                    characteristic_length,
-                                                    *logger);
+        auto solver = BoxConstraintSolver::create(
+            solver_params, linear_solver_params, characteristic_length, *logger);
 
         auto c = std::make_shared<InequalityConstraint>(solver_params["box_constraints"]["bounds"][1]);
-        dynamic_cast<BoxConstraintSolver&>(*solver).add_constraint(c);
+        dynamic_cast<BoxConstraintSolver &>(*solver).add_constraint(c);
 
         QuadraticProblem::TVector x(prob->size());
         x.setConstant(3);


### PR DESCRIPTION
* Implement the numerically robust Armijo line search of Longva et al. [2023]

TODO:
* [x] Re-enable `use_grad_norm`
* [x] Only compute `new_grad` as needed