### PR TITLE
add solver_info to PostStepData

### DIFF
--- a/src/polysolve/nonlinear/PostStepData.cpp
+++ b/src/polysolve/nonlinear/PostStepData.cpp
@@ -3,9 +3,10 @@
 namespace polysolve::nonlinear
 {
     PostStepData::PostStepData(const int iter_num,
+                               const json &solver_info,
                                const Eigen::VectorXd &x,
                                const Eigen::VectorXd &grad)
-        : iter_num(iter_num), x(x), grad(grad)
+        : iter_num(iter_num), solver_info(solver_info), x(x), grad(grad)
     {
     }
 } // namespace polysolve::nonlinear

--- a/src/polysolve/nonlinear/PostStepData.hpp
+++ b/src/polysolve/nonlinear/PostStepData.hpp
@@ -9,10 +9,12 @@ namespace polysolve::nonlinear
     {
     public:
         PostStepData(const int iter_num,
+                     const json &solver_info,
                      const Eigen::VectorXd &x,
                      const Eigen::VectorXd &grad);
 
         const int iter_num;
+        const json &solver_info;
         const Eigen::VectorXd &x;
         const Eigen::VectorXd &grad;
     };


### PR DESCRIPTION
1. Call update_solver_info before passing solver_info to post_step
2. Move post_step up, so that it's called before the solver stops by user-defined condition