### PR TITLE
Add set_block_size and set_is_nullspace for linear sovler

### DIFF
--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -111,7 +111,7 @@ namespace polysolve::linear
         virtual void set_block_size(int block_size) {}
 
         // If the problem is nullspace for multigrid solvers
-        virtual void set_is_nullspace(bool is_nullspace) {}
+        virtual void set_is_nullspace(const VectorXd &x) {}
 
         //
         // @brief         { Solve the linear system Ax = b }

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -107,6 +107,12 @@ namespace polysolve::linear
         // If solver uses dense matrices
         virtual bool is_dense() const { return false; }
 
+        // Set block size for multigrid solvers
+        virtual void set_block_size(int block_size) {}
+
+        // If the problem is nullspace for multigrid solvers
+        virtual void set_is_nullspace(bool is_nullspace) {}
+
         //
         // @brief         { Solve the linear system Ax = b }
         //


### PR DESCRIPTION
Add set_block_size and set_is_nullspace methods for linear sovler class.
block_size and is_nullspace are used in multigrid solvers.