### PR TITLE
updating boost url due to a redirection error

### DIFF
--- a/cmake/recipes/boost.cmake
+++ b/cmake/recipes/boost.cmake
@@ -20,7 +20,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(OLD_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2" CACHE STRING "Boost download URL")
+set(BOOST_URL 
+    "https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.bz2"
+    CACHE STRING "Boost download URL")
 set(BOOST_URL_SHA256 "6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e" CACHE STRING "Boost download URL SHA256 checksum")
 
 include(CPM)


### PR DESCRIPTION
The current url gives me the following:
```
❯ wget https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2
--2025-01-03 21:44:50--  https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2
Resolving boostorg.jfrog.io... 18.214.194.113, 3.95.117.170, 18.232.172.199
Connecting to boostorg.jfrog.io|18.214.194.113|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://landing.jfrog.com/reactivate-server/boostorg [following]
--2025-01-03 21:44:50--  https://landing.jfrog.com/reactivate-server/boostorg
Resolving landing.jfrog.com... 18.214.194.113, 18.232.172.199, 3.95.117.170
Connecting to landing.jfrog.com|18.214.194.113|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11534 (11K) [text/html]
Saving to: ‘boost_1_83_0.tar.bz2’
```
(note that the file is `text/html` / is not a tarball upon verification). Updating with a url found here:
https://www.boost.org/users/history/version_1_83_0.html