### PR TITLE
Disable MAS solver on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,12 @@ if(POLYSOLVE_WITH_CUDA)
   target_compile_definitions(polysolve_linear PUBLIC POLYSOLVE_WITH_CUDA)
 endif()
 
+# Graph partition library Kaminpar does not support windows.
+if(POLYSOLVE_WITH_CUDA AND NOT WIN32)
+  target_compile_definitions(polysolve PUBLIC POLYSOLVE_WITH_MAS)
+  target_compile_definitions(polysolve_linear PUBLIC POLYSOLVE_WITH_MAS)
+endif()
+
 ################################################################################
 # Dependencies
 ################################################################################
@@ -413,7 +419,7 @@ endif()
 
 # KaMinPar
 # KaMinPar requires onetbb
-if(POLYSOLVE_WITH_CUDA)
+if(POLYSOLVE_WITH_CUDA AND NOT WIN32)
   include(kaminpar)
   target_link_libraries(polysolve_linear PRIVATE KaMinPar::KaMinPar)
 endif()

--- a/src/polysolve/linear/CMakeLists.txt
+++ b/src/polysolve/linear/CMakeLists.txt
@@ -17,7 +17,7 @@ set(SOURCES
     SaddlePointSolver.hpp
 )
 
-if(POLYSOLVE_WITH_CUDA)
+if(POLYSOLVE_WITH_CUDA AND NOT WIN32)
     list(APPEND SOURCES
         MASSolver.cu
         MASSolver.hpp

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -68,7 +68,7 @@ namespace polysolve::linear
 #ifdef POLYSOLVE_WITH_CUSOLVER
 #include "CuSolverDN.cuh"
 #endif
-#ifdef POLYSOLVE_WITH_CUDA
+#ifdef POLYSOLVE_WITH_MAS
 #include "MASSolver.hpp"
 #endif
 
@@ -400,7 +400,7 @@ namespace polysolve::linear
         {
             return std::make_unique<CuSolverDN<float>>();
 #endif
-#ifdef POLYSOLVE_WITH_CUDA
+#ifdef POLYSOLVE_WITH_MAS
         }
         else if (solver == "MAS")
         {
@@ -538,7 +538,7 @@ namespace polysolve::linear
             "cuSolverDN",
             "cuSolverDN_float",
 #endif
-#ifdef POLYSOLVE_WITH_CUDA
+#ifdef POLYSOLVE_WITH_MAS
             "MAS",
 #endif
 #ifdef POLYSOLVE_WITH_HYPRE


### PR DESCRIPTION

Graph parition library Kaminpar does not support windows. Alternative is METIS but is too slow, negating the benefits of MAS sovler.
