### PR TITLE
Update Eigen to 5.0.1 and fix resulting MSVC SparseQR build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/data
 *.code-workspace
 PolySolveOptions.cmake
 .vs
+__cmake_systeminformation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(POLYSOLVE_TOPLEVEL_PROJECT)
     cmake_minimum_required(VERSION ${REQUIRED_CMAKE_VERSION})
     SET(CMAKE_POLICY_VERSION_MINIMUM ${REQUIRED_CMAKE_VERSION})
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0.0")
-        message(WARNING "CMake version is ${CMAKE_VERSION}, setting stuff for dependencies.")
+        message(WARNING "CMake version ${CMAKE_VERSION} >= 4.0.0, setting CMAKE_POLICY_VERSION_MINIMUM to ${REQUIRED_CMAKE_VERSION} and disabling AMGCL.")
         SET(CMAKE_POLICY_VERSION_MINIMUM ${REQUIRED_CMAKE_VERSION})
         set(POLYSOLVE_WITH_AMGCL OFF CACHE BOOL "Use AMGCL for solving linear systems")
     endif()
@@ -277,13 +277,6 @@ endif()
 
 # Accelerate solver (Include before Eigen)
 if(POLYSOLVE_WITH_ACCELERATE)
-    include(CPM)
-    CPMAddPackage(
-        NAME eigen
-        GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-        GIT_TAG 969c31eefcdfaab11da763bea3f7502086673ab0
-        DOWNLOAD_ONLY ON
-    )
     set(BLA_VENDOR Apple)
     find_package(BLAS REQUIRED)
     find_package(LAPACK REQUIRED)

--- a/cmake/recipes/eigen.cmake
+++ b/cmake/recipes/eigen.cmake
@@ -23,7 +23,7 @@ include(CPM)
 CPMAddPackage(
     NAME eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-    GIT_TAG 3.4.0
+    GIT_TAG 5.0.1
     DOWNLOAD_ONLY ON
 )
 

--- a/cmake/recipes/json.cmake
+++ b/cmake/recipes/json.cmake
@@ -16,20 +16,21 @@ endif()
 message(STATUS "Third-party: creating target 'nlohmann_json::nlohmann_json'")
 
 # nlohmann_json is a big repo for a single header, so we just download the release archive
-set(NLOHMANNJSON_VERSION "v3.11.2")
+set(NLOHMANNJSON_VERSION "v3.12.0")
 
 include(CPM)
 CPMAddPackage(
     NAME nlohmann_json
     URL "https://github.com/nlohmann/json/releases/download/${NLOHMANNJSON_VERSION}/include.zip"
-    URL_HASH SHA256=e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed
+    URL_HASH SHA256=b8cb0ef2dd7f57f18933997c9934bb1fa962594f701cd5a8d3c2c80541559372
+    DOWNLOAD_ONLY YES
 )
 
 add_library(nlohmann_json INTERFACE)
 add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
 
 include(GNUInstallDirs)
-target_include_directories(nlohmann_json INTERFACE
+target_include_directories(nlohmann_json SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${nlohmann_json_SOURCE_DIR}>/include"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )

--- a/nonlinear-solver-spec.json
+++ b/nonlinear-solver-spec.json
@@ -15,6 +15,7 @@
             "iterations_per_strategy",
             "line_search",
             "allow_out_of_iterations",
+            "allow_non_grad_convergence",
             "L-BFGS",
             "L-BFGS-B",
             "Newton",
@@ -124,6 +125,12 @@
         "default": false,
         "type": "bool",
         "doc": "If false (default), an exception will be thrown when the nonlinear solver reaches the maximum number of iterations."
+    },
+    {
+        "pointer": "/allow_non_grad_convergence",
+        "default": false,
+        "type": "bool",
+        "doc": "If false (default), only convergence via the gradient norm tolerance is logged as a success; convergence via any other tolerance (e.g., x delta, f delta) is logged as an error. If true, convergence via any tolerance is logged as a success."
     },
     {
         "pointer": "/L-BFGS",

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -11,15 +11,6 @@
 
 #include <fstream>
 
-// -----------------------------------------------------------------------------
-//
-// Subsequent macros assume a single template parameter and SparseQR fails due to requiring 2 parameters. this is because the OrderingType is not filled in.
-// SparseLU has a default declaration of _OrderingType to use COLAMDOrdering but SparseQR doesn't - so this just mimics that behavior. If Eigen adds such a default in the future this line will need to be guarded to avoid multiple defaults
-namespace Eigen
-{
-    template <typename _MatrixType, typename _OrderingType = COLAMDOrdering<typename _MatrixType::StorageIndex>>
-    class SparseQR;
-}
 #include <Eigen/Sparse>
 #ifdef POLYSOLVE_WITH_ACCELERATE
 #include <Eigen/AccelerateSupport>
@@ -264,6 +255,12 @@ namespace polysolve::linear
     namespace
     {
 
+        // Eigen::SparseQR (unlike Eigen::SparseLU) has no default OrderingType, so it cannot
+        // be used directly with RETURN_DIRECT_SOLVER_PTR, which only supplies the matrix type.
+        // This alias fills in the default ordering explicitly.
+        template <typename MatrixType>
+        using SparseQRWithDefaultOrdering = Eigen::SparseQR<MatrixType, Eigen::COLAMDOrdering<typename MatrixType::StorageIndex>>;
+
         template <template <class, class> class SparseSolver, typename Precond>
         struct MakeSolver
         {
@@ -321,7 +318,7 @@ namespace polysolve::linear
         }
         else if (solver == "Eigen::SparseQR")
         {
-            RETURN_DIRECT_SOLVER_PTR(SparseQR, "Eigen::SparseQR");
+            RETURN_DIRECT_SOLVER_PTR(SparseQRWithDefaultOrdering, "Eigen::SparseQR");
 #ifdef POLYSOLVE_WITH_ACCELERATE
         }
         else if (solver == "Eigen::AccelerateLLT")

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -543,7 +543,7 @@ namespace polysolve::nonlinear
 
         double tot_time = stop_watch.getElapsedTimeInSec();
         const bool succeeded = m_status == Status::GradNormTolerance || m_status == Status::RelGradNormTolerance
-                                || (allow_non_grad_convergence && is_converged_status(m_status));
+                               || (allow_non_grad_convergence && is_converged_status(m_status));
         m_logger.log(
             succeeded ? spdlog::level::info : spdlog::level::err,
             "[{}][{}] Finished: {} took {:g}s ({}) (stopping criteria: {})",
@@ -678,6 +678,7 @@ namespace polysolve::nonlinear
         break;
         default:
             log_and_throw_error(m_logger, "Unrecognized gradient verification strategy: {}", static_cast<int>(gradient_fd_strategy));
+        }
 
         objFunc.solution_changed(x);
     }

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -215,6 +215,7 @@ namespace polysolve::nonlinear
 
         m_stop.iterations = solver_params["max_iterations"];
         allow_out_of_iterations = solver_params["allow_out_of_iterations"];
+        allow_non_grad_convergence = solver_params["allow_non_grad_convergence"];
 
         m_stop.fDeltaCount = solver_params["advanced"]["f_delta_step_tol"];
 
@@ -541,7 +542,8 @@ namespace polysolve::nonlinear
             log_and_throw_error(m_logger, "[{}][{}] Failed to find minimizer", descent_strategy_name(), m_line_search->name());
 
         double tot_time = stop_watch.getElapsedTimeInSec();
-        const bool succeeded = m_status == Status::GradNormTolerance || m_status == Status::RelGradNormTolerance;
+        const bool succeeded = m_status == Status::GradNormTolerance || m_status == Status::RelGradNormTolerance
+                                || (allow_non_grad_convergence && is_converged_status(m_status));
         m_logger.log(
             succeeded ? spdlog::level::info : spdlog::level::err,
             "[{}][{}] Finished: {} took {:g}s ({}) (stopping criteria: {})",
@@ -674,6 +676,8 @@ namespace polysolve::nonlinear
                 m_logger.error("step size: {}, all gradient components do not match finite difference", gradient_fd_eps);
         }
         break;
+        default:
+            log_and_throw_error(m_logger, "Unrecognized gradient verification strategy: {}", gradient_fd_strategy);
         }
 
         objFunc.solution_changed(x);

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -677,8 +677,7 @@ namespace polysolve::nonlinear
         }
         break;
         default:
-            log_and_throw_error(m_logger, "Unrecognized gradient verification strategy: {}", gradient_fd_strategy);
-        }
+            log_and_throw_error(m_logger, "Unrecognized gradient verification strategy: {}", static_cast<int>(gradient_fd_strategy));
 
         objFunc.solution_changed(x);
     }

--- a/src/polysolve/nonlinear/Solver.hpp
+++ b/src/polysolve/nonlinear/Solver.hpp
@@ -81,6 +81,9 @@ namespace polysolve::nonlinear
         /// @brief If true the solver will not throw an error if the maximum number of iterations is reached
         bool allow_out_of_iterations = false;
 
+        /// @brief If true, converging via a non-gradient criterion (e.g., x/f delta tolerance) is logged as a success instead of an error
+        bool allow_non_grad_convergence = false;
+
 
         /// @brief Get the line search object
         const std::shared_ptr<line_search::LineSearch> &line_search() const { return m_line_search; };


### PR DESCRIPTION
## Summary

- Bumps the Eigen dependency from 3.4.0 to 5.0.1 (`cmake/recipes/eigen.cmake`), and updates nlohmann_json to v3.12.0 (`cmake/recipes/json.cmake`).
- Removes a now-redundant duplicate `CPMAddPackage` for Eigen under `POLYSOLVE_WITH_ACCELERATE` in `CMakeLists.txt` (the top-level `eigen.cmake` recipe already provides it), and marks nlohmann_json's include directories as `SYSTEM` to suppress warnings originating from the dependency.
- Fixes an MSVC build failure (`C2653`/`C2146`/`C2976`) in `src/polysolve/linear/Solver.cpp` that the Eigen bump exposed: a workaround forward-declared `Eigen::SparseQR` with a default `OrderingType` (unlike `Eigen::SparseLU`, `SparseQR` doesn't provide one out of the box), but that declaration ran *after* `Eigen::SparseQR` was already fully defined via a transitive include, which MSVC couldn't parse with Eigen 5.0.1. Replaced it with an explicit alias template (`SparseQRWithDefaultOrdering`) that fills in the ordering type directly, instead of relying on redeclaring a template's default argument.
- Adds an `allow_non_grad_convergence` option to the nonlinear solver (default `false`, preserving current behavior). Previously only `GradNormTolerance`/`RelGradNormTolerance` were treated as "succeeded" for logging purposes, so converging via any other valid tolerance (x delta, f delta, rel x delta, Newton decrement) was logged at `error` level even though the solve succeeded. When enabled, convergence via any of these tolerances is now logged as a success.

## Motivation

Bumping Eigen surfaced a latent, MSVC-specific bug in the `SparseQR` forward-declaration hack, breaking Windows CI builds downstream. The nonlinear solver logging change was made alongside this work to stop noisy false-positive error logs for legitimate non-gradient-based convergence.

## Test plan

- [x] Rebuilt `polysolve` and `polysolve_linear` locally against Eigen 5.0.1 — both compile cleanly.
- [ ] Confirm Windows CI (MSVC) build passes with the `SparseQR` fix.