### PR TITLE
Fix O(m^2) assembly in HypreSolver::factorize

### DIFF
--- a/src/polysolve/linear/HypreSolver.cpp
+++ b/src/polysolve/linear/HypreSolver.cpp
@@ -106,26 +106,22 @@ namespace polysolve::linear
 
         // HYPRE_IJMatrixSetValues(A, 1, &nnz, &i, cols, values);
 
-        // TODO: More efficient initialization of the Hypre matrix?
+        // Build each column once and set it in a single call -> O(nnz).
+        std::vector<HYPRE_Int> col_idx;
+        std::vector<double> vals;
         for (HYPRE_Int k = 0; k < Ain.outerSize(); ++k)
         {
+            col_idx.clear();
+            vals.clear();
             for (StiffnessMatrix::InnerIterator it(Ain, k); it; ++it)
             {
-                HYPRE_Int row[1]; 
-                int counter = 0;
-                std::vector<HYPRE_Int> cols;
-                std::vector<double> vals;
-                for (StiffnessMatrix::InnerIterator it(Ain, k); it; ++it)
-                {
-                    // since A is symmetric, we swap rows and columns for more efficient initialization
-                    ++counter;
-                    row[0] = it.col();
-                    cols.push_back((HYPRE_Int)it.row());
-                    vals.push_back(it.value());
-                }
-                HYPRE_Int n_cols[1] = {counter};
-                HYPRE_IJMatrixSetValues(A, 1, n_cols, row, cols.data(), vals.data());
+                // since A is symmetric, we swap rows and columns for more efficient initialization
+                col_idx.push_back((HYPRE_Int)it.row());
+                vals.push_back(it.value());
             }
+            HYPRE_Int row[1] = {(HYPRE_Int)k};
+            HYPRE_Int n_cols[1] = {(HYPRE_Int)col_idx.size()};
+            HYPRE_IJMatrixSetValues(A, 1, n_cols, row, col_idx.data(), vals.data());
         }
 
         HYPRE_IJMatrixAssemble(A);


### PR DESCRIPTION
### Problem
`HypreSolver::factorize` builds the HYPRE matrix with a nested loop: for **each** nonzero
in a column it rebuilds and re-sets the **entire** column, so every column is handed to
`HYPRE_IJMatrixSetValues` `nnz(col)` times. Assembly is therefore **O(m^2)** in the number
of nonzeros and dominates solve setup on large matrices.

### Fix
Build each column's index/value arrays once and set it in a single `HYPRE_IJMatrixSetValues`
call -> **O(nnz)** total. The assembled matrix (and the
solution) is unchanged.

### Testing
- Builds clean.
- Full `ctest` suite passes 27/27, including `hypre` and `hypre_initial_guess`.

@maxpaik16 PTAL, thanks!