### PR TITLE
Fixes the build failure when configuring with POLYSOLVE_LARGE_INDEX=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,13 +275,17 @@ endif()
 # Linear
 # ------
 
-# Accelerate solver (Include before Eigen)
+
 if(POLYSOLVE_WITH_ACCELERATE)
-    set(BLA_VENDOR Apple)
-    find_package(BLAS REQUIRED)
-    find_package(LAPACK REQUIRED)
-    target_link_libraries(polysolve_linear PRIVATE BLAS::BLAS LAPACK::LAPACK)
-    target_compile_definitions(polysolve_linear PUBLIC POLYSOLVE_WITH_ACCELERATE)
+    if(POLYSOLVE_LARGE_INDEX)
+        message(STATUS "POLYSOLVE_LARGE_INDEX is ON: disabling Apple Accelerate (it only supports 32-bit sparse indices).")
+    else()
+        set(BLA_VENDOR Apple)
+        find_package(BLAS REQUIRED)
+        find_package(LAPACK REQUIRED)
+        target_link_libraries(polysolve_linear PRIVATE BLAS::BLAS LAPACK::LAPACK)
+        target_compile_definitions(polysolve_linear PUBLIC POLYSOLVE_WITH_ACCELERATE)
+    endif()
 endif()
 
 include(eigen)

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -45,7 +45,11 @@ namespace polysolve::linear
 #include <Eigen/SuperLUSupport>
 #endif
 #ifdef POLYSOLVE_WITH_MKL
+#ifndef POLYSOLVE_LARGE_INDEX
+// Eigen's PardisoSupport only specializes for int/long long indices, not the
+// std::ptrdiff_t (long) StiffnessMatrix used with POLYSOLVE_LARGE_INDEX.
 #include <Eigen/PardisoSupport>
+#endif
 #endif
 #ifdef POLYSOLVE_WITH_PARDISO
 #include "Pardiso.hpp"
@@ -368,6 +372,7 @@ namespace polysolve::linear
             RETURN_DIRECT_SOLVER_PTR(SPQR, "Eigen::SPQR");
 #endif
 #ifdef POLYSOLVE_WITH_MKL
+#ifndef POLYSOLVE_LARGE_INDEX
         }
         else if (solver == "Eigen::PardisoLLT")
         {
@@ -380,6 +385,7 @@ namespace polysolve::linear
         else if (solver == "Eigen::PardisoLU")
         {
             RETURN_DIRECT_SOLVER_PTR(PardisoLU, "Eigen::PardisoLU");
+#endif
 #endif
 #ifdef POLYSOLVE_WITH_PARDISO
         }
@@ -524,9 +530,11 @@ namespace polysolve::linear
             "Eigen::SPQR",
 #endif
 #ifdef POLYSOLVE_WITH_MKL
+#ifndef POLYSOLVE_LARGE_INDEX
             "Eigen::PardisoLLT",
             "Eigen::PardisoLDLT",
             "Eigen::PardisoLU",
+#endif
 #endif
 #ifdef POLYSOLVE_WITH_PARDISO
             "Pardiso",


### PR DESCRIPTION
With large indices, StiffnessMatrix uses 64-bit (std::ptrdiff_t) indices, but two of the wrapped direct solvers are 32-bit int-only and fail to compile against it:

- Apple Accelerate — the Accelerate sparse API is int-only, with no 64-bit variant. Disabled in CMake when POLYSOLVE_LARGE_INDEX is on, so the macro is never defined and no Accelerate code is compiled. (This is the macOS compile error seen on the large-index build.)
- MKL Pardiso — Eigen's PardisoSupport only specializes pardiso_run_selector for int/long long, not long (std::ptrdiff_t). Excluded under #ifndef POLYSOLVE_LARGE_INDEX, mirroring the existing UmfPack handling. MKL's BLAS/LAPACK backend is left enabled.

This PR only makes the large-index build compile — it does not add large-index support to those solvers (that's future work). SuperLU has the same int-only limitation and is left untouched here.

Testing

- Linux: library builds and the unit tests pass with POLYSOLVE_LARGE_INDEX=ON.
- Apple Silicon (Accelerate on by default): the large-index build now compiles — both polysolve standalone, and inside a polyfem build that points its polysolve dependency at this branch.

@maxpaik16 PTAL! Thanks