### PR TITLE
Integration of BlockCatamari/MeshFEMSparse

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/MeshFEM_dev"]
+	path = 3rdparty/MeshFEM_dev
+	url = git@github.com:MeshFEM/MeshFEM_dev.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/MeshFEM_dev"]
-	path = 3rdparty/MeshFEM_dev
-	url = git@github.com:MeshFEM/MeshFEM_dev.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,19 @@ endif()
 include(polysolve_warnings)
 target_link_libraries(polysolve PRIVATE polysolve::warnings)
 
+# MeshFEM
+set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
+
+if (NOT TARGET MeshFEM)
+    option(MESHFEM_ENABLE_BENCHMARKING "" ON)
+    option(MESHFEM_WITH_IPC_TOOLKIT "" OFF) # avoid conflicting IPC toolkit versions.
+    add_subdirectory(${THIRD_PARTY_DIR}/MeshFEM_dev)
+endif()
+target_link_libraries(polyfem PUBLIC MeshFEM)
+
+# Color errors/warnings.
+list(APPEND CMAKE_MODULE_PATH ${THIRD_PARTY_DIR}/MeshFEM_dev/cmake)
+include(UseColors)
 
 ################################################################################
 # Specs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0135 NEW) # Set the timestamps of all extracted cont
 
 project(PolySolve
         DESCRIPTION "Easy-to-use wrapper for linear solver"
-        LANGUAGES CXX)
+        LANGUAGES C CXX)
 
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND APPLE)
     set(POLYSOLVE_NOT_ON_APPLE_SILICON OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,19 @@ if(POLYSOLVE_WITH_CUDA AND NOT WIN32)
   target_link_libraries(polysolve_linear PRIVATE KaMinPar::KaMinPar)
 endif()
 
+# MeshFEM
+# Color errors/warnings.
+list(APPEND CMAKE_MODULE_PATH ${THIRD_PARTY_DIR}/MeshFEM_dev/cmake)
+# include(UseColors)
+set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
+
+if (NOT TARGET MeshFEM)
+    option(MESHFEM_ENABLE_BENCHMARKING "" ON)
+    option(MESHFEM_WITH_IPC_TOOLKIT "" OFF) # avoid conflicting IPC toolkit versions.
+    add_subdirectory(${THIRD_PARTY_DIR}/MeshFEM_dev)
+endif()
+target_link_libraries(polysolve_linear PUBLIC MeshFEM)
+
 # ---------
 # Nonlinear
 # ---------
@@ -441,20 +454,6 @@ endif()
 # Extra warnings (include last for highest priority)
 include(polysolve_warnings)
 target_link_libraries(polysolve PRIVATE polysolve::warnings)
-
-# MeshFEM
-set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
-
-if (NOT TARGET MeshFEM)
-    option(MESHFEM_ENABLE_BENCHMARKING "" ON)
-    option(MESHFEM_WITH_IPC_TOOLKIT "" OFF) # avoid conflicting IPC toolkit versions.
-    add_subdirectory(${THIRD_PARTY_DIR}/MeshFEM_dev)
-endif()
-target_link_libraries(polysolve PUBLIC MeshFEM)
-
-# Color errors/warnings.
-list(APPEND CMAKE_MODULE_PATH ${THIRD_PARTY_DIR}/MeshFEM_dev/cmake)
-include(UseColors)
 
 ################################################################################
 # Specs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,7 @@ if(POLYSOLVE_WITH_SUPERLU)
     endif()
 endif()
 
-# SuiteSpraseQR
+# SuiteSparseQR
 if(POLYSOLVE_WITH_SPQR)
     include(spqr)
     if(TARGET SuiteSparse::SPQR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,7 @@ if(POLYSOLVE_WITH_SUPERLU)
     endif()
 endif()
 
-# SuperLU solver
+# SuiteSpraseQR
 if(POLYSOLVE_WITH_SPQR)
     include(spqr)
     if(TARGET SuiteSparse::SPQR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,7 @@ if (NOT TARGET MeshFEM)
     option(MESHFEM_WITH_IPC_TOOLKIT "" OFF) # avoid conflicting IPC toolkit versions.
     add_subdirectory(${THIRD_PARTY_DIR}/MeshFEM_dev)
 endif()
-target_link_libraries(polyfem PUBLIC MeshFEM)
+target_link_libraries(polysolve PUBLIC MeshFEM)
 
 # Color errors/warnings.
 list(APPEND CMAKE_MODULE_PATH ${THIRD_PARTY_DIR}/MeshFEM_dev/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,10 @@ if(POLYSOLVE_WITH_CUSOLVER)
     endif()
 endif()
 
+# MeshFEMSparse
+include(meshfemsparse)
+target_link_libraries(polysolve_linear PUBLIC MeshFEMSparse)
+
 # Sanitizers
 if(POLYSOLVE_WITH_SANITIZERS)
     include(sanitizers)
@@ -416,19 +420,6 @@ if(POLYSOLVE_WITH_CUDA AND NOT WIN32)
   include(kaminpar)
   target_link_libraries(polysolve_linear PRIVATE KaMinPar::KaMinPar)
 endif()
-
-# MeshFEM
-# Color errors/warnings.
-list(APPEND CMAKE_MODULE_PATH ${THIRD_PARTY_DIR}/MeshFEM_dev/cmake)
-# include(UseColors)
-set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty)
-
-if (NOT TARGET MeshFEM)
-    option(MESHFEM_ENABLE_BENCHMARKING "" ON)
-    option(MESHFEM_WITH_IPC_TOOLKIT "" OFF) # avoid conflicting IPC toolkit versions.
-    add_subdirectory(${THIRD_PARTY_DIR}/MeshFEM_dev)
-endif()
-target_link_libraries(polysolve_linear PUBLIC MeshFEM)
 
 # ---------
 # Nonlinear

--- a/cmake/recipes/catch2.cmake
+++ b/cmake/recipes/catch2.cmake
@@ -28,7 +28,7 @@ CPMAddPackage(
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
     # See https://github.com/catchorg/Catch2/issues/2654
-    target_compile_options(Catch2 PUBLIC -Wno-parentheses)
+    target_compile_options(Catch2 INTERFACE -Wno-parentheses)
 endif()
 
 set_target_properties(Catch2 PROPERTIES FOLDER third_party)

--- a/cmake/recipes/gklib.cmake
+++ b/cmake/recipes/gklib.cmake
@@ -1,0 +1,56 @@
+if(TARGET GKlib::GKlib)
+    return()
+endif()
+
+message(STATUS "Third-party: creating target 'GKlib::GKlib'")
+
+# Note: the version here is chosen to match `wildmeshing-toolkit`.
+include(FetchContent)
+FetchContent_Declare(
+    gklib
+    GIT_REPOSITORY https://github.com/KarypisLab/GKlib.git
+    GIT_TAG        a7f8172703cf6e999dd0710eb279bba513da4fec
+)
+
+FetchContent_GetProperties(gklib)
+if(NOT gklib_POPULATED)
+    FetchContent_Populate(gklib)
+endif()
+
+file(GLOB INC_FILES "${gklib_SOURCE_DIR}/*.h")
+file(GLOB SRC_FILES "${gklib_SOURCE_DIR}/*.c")
+if(NOT MSVC)
+    list(REMOVE_ITEM SRC_FILES "${gklib_SOURCE_DIR}/gkregex.c")
+endif()
+
+add_library(GKlib STATIC ${INC_FILES} ${SRC_FILES})
+add_library(GKlib::GKlib ALIAS GKlib)
+
+if(MSVC)
+    target_compile_definitions(GKlib PUBLIC USE_GKREGEX)
+    target_compile_definitions(GKlib PUBLIC "__thread=__declspec(thread)")
+endif()
+
+file(MAKE_DIRECTORY "${gklib_BINARY_DIR}/include/gklib")
+configure_file("${gklib_SOURCE_DIR}/gk_ms_stdint.h" "${gklib_BINARY_DIR}/include/gklib/ms_stdint.h" COPYONLY)
+
+target_include_directories(GKlib SYSTEM PUBLIC
+    "$<BUILD_INTERFACE:${gklib_SOURCE_DIR}>"
+    "$<BUILD_INTERFACE:${gklib_BINARY_DIR}/include/gklib>"
+)
+
+set_target_properties(GKlib PROPERTIES FOLDER third_party)
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
+   "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(GKlib PRIVATE
+        "-Wno-unused-variable"
+        "-Wno-sometimes-uninitialized"
+        "-Wno-absolute-value"
+        "-Wno-shadow"
+    )
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    target_compile_options(GKlib PRIVATE "-w")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    target_compile_options(GKlib PRIVATE "/w")
+endif()

--- a/cmake/recipes/meshfemsparse.cmake
+++ b/cmake/recipes/meshfemsparse.cmake
@@ -6,7 +6,7 @@ endif()
 
 message(STATUS "Third-party: creating target 'MeshFEMSparse'")
 
-set(MESHFEMSPARSE_GIT_REPOSITORY "git@github.com:MeshFEM/MeshFEMSparse.git" CACHE STRING "MeshFEMSparse git repository")
+set(MESHFEMSPARSE_GIT_REPOSITORY "https://github.com/MeshFEM/MeshFEMSparse.git" CACHE STRING "MeshFEMSparse git repository")
 set(MESHFEMSPARSE_GIT_TAG "main" CACHE STRING "MeshFEMSparse git revision")
 
 include(CPM)

--- a/cmake/recipes/meshfemsparse.cmake
+++ b/cmake/recipes/meshfemsparse.cmake
@@ -1,0 +1,17 @@
+# MeshFEMSparse
+
+if(TARGET MeshFEMSparse)
+    return()
+endif()
+
+message(STATUS "Third-party: creating target 'MeshFEMSparse'")
+
+set(MESHFEMSPARSE_GIT_REPOSITORY "git@github.com:MeshFEM/MeshFEMSparse.git" CACHE STRING "MeshFEMSparse git repository")
+set(MESHFEMSPARSE_GIT_TAG "main" CACHE STRING "MeshFEMSparse git revision")
+
+include(CPM)
+CPMAddPackage(
+    NAME MeshFEMSparse
+    GIT_REPOSITORY ${MESHFEMSPARSE_GIT_REPOSITORY}
+    GIT_TAG ${MESHFEMSPARSE_GIT_TAG}
+)

--- a/cmake/recipes/meshfemsparse.cmake
+++ b/cmake/recipes/meshfemsparse.cmake
@@ -8,6 +8,7 @@ message(STATUS "Third-party: creating target 'MeshFEMSparse'")
 
 set(MESHFEMSPARSE_GIT_REPOSITORY "https://github.com/MeshFEM/MeshFEMSparse.git" CACHE STRING "MeshFEMSparse git repository")
 set(MESHFEMSPARSE_GIT_TAG "main" CACHE STRING "MeshFEMSparse git revision")
+set(MESHFEM_NATIVE OFF CACHE BOOL "Add march=native flag to MeshFEM targets") # Setting this "ON" currently breaks PolyFEM on x86 due to Eigen ABI mismatch across its TUs (particularly the autogen ones)
 
 include(CPM)
 CPMAddPackage(

--- a/cmake/recipes/metis.cmake
+++ b/cmake/recipes/metis.cmake
@@ -1,0 +1,51 @@
+if(TARGET metis::metis)
+    return()
+endif()
+
+message(STATUS "Third-party: creating target 'metis::metis'")
+
+# Note: the version/compilation settings defined in here are chosen to match
+# those in `wildmeshing-toolkit`.
+include(FetchContent)
+FetchContent_Declare(
+    metis
+    GIT_REPOSITORY https://github.com/KarypisLab/METIS.git
+    GIT_TAG        94c03a6e2d1860128c2d0675cbbb86ad4f261256
+)
+
+FetchContent_GetProperties(metis)
+if(NOT metis_POPULATED)
+    FetchContent_Populate(metis)
+endif()
+
+file(GLOB INC_FILES "${metis_SOURCE_DIR}/libmetis/*.h")
+file(GLOB SRC_FILES "${metis_SOURCE_DIR}/libmetis/*.c")
+
+add_library(metis STATIC ${INC_FILES} ${SRC_FILES})
+add_library(metis::metis ALIAS metis)
+
+include(gklib)
+target_link_libraries(metis PRIVATE GKlib::GKlib)
+
+target_include_directories(metis PRIVATE "${metis_SOURCE_DIR}/libmetis")
+target_include_directories(metis SYSTEM PUBLIC "$<BUILD_INTERFACE:${metis_SOURCE_DIR}/include>")
+
+target_compile_definitions(metis PUBLIC -DIDXTYPEWIDTH=32)
+target_compile_definitions(metis PUBLIC -DREALTYPEWIDTH=32)
+
+set(POLYSOLVE_METIS_SOURCE_DIR "${metis_SOURCE_DIR}" CACHE INTERNAL "")
+set_target_properties(metis PROPERTIES FOLDER third_party)
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
+   "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(metis PRIVATE
+        "-Wno-unused-variable"
+        "-Wno-sometimes-uninitialized"
+        "-Wno-absolute-value"
+        "-Wno-shadow"
+    )
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    target_compile_options(metis PRIVATE "-w")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    target_compile_options(metis PRIVATE "/w")
+endif()

--- a/cmake/recipes/mkl.cmake
+++ b/cmake/recipes/mkl.cmake
@@ -34,10 +34,10 @@ set_property(CACHE MKL_LINKING PROPERTY STRINGS ${MKL_LINKINK_CHOICES})
 message(STATUS "MKL linking strategy: ${MKL_LINKING}")
 
 # MKL version
-set(MKL_VERSION "2022.2.1" CACHE STRING "MKL version to use (2022.2.1)")
+set(MKL_VERSION "2022.2.1" CACHE STRING "CPM MKL version to use (2022.2.1)")
 set(MKL_VERSION_CHOICES 2022.2.1)
 set_property(CACHE MKL_VERSION PROPERTY STRINGS ${MKL_VERSION_CHOICES})
-message(STATUS "MKL version: ${MKL_VERSION}")
+message(STATUS "CPM MKL version: ${MKL_VERSION}")
 
 ################################################################################
 
@@ -59,6 +59,13 @@ endif()
 if(MKL_LINKING STREQUAL sdl)
     message(FATAL_ERROR "MKL_LINKING=sdl is not fully supported yet.")
 endif()
+
+include(try_system_mkl)
+if(TARGET mkl::mkl)
+    return()
+endif()
+
+################################################################################
 
 # Check option for the library version
 if(NOT MKL_VERSION IN_LIST MKL_VERSION_CHOICES)

--- a/cmake/recipes/spqr.cmake
+++ b/cmake/recipes/spqr.cmake
@@ -1,6 +1,7 @@
-# SPQR solver
+# SuiteSparseQR
 
-if(TARGET SparseSuite::SPQR)
+include(suitesparse)
+if(TARGET SuiteSparse::SPQR)
     return()
 endif()
 

--- a/cmake/recipes/suitesparse.cmake
+++ b/cmake/recipes/suitesparse.cmake
@@ -23,8 +23,8 @@ message(STATUS "Third-party: creating targets 'SuiteSparse::CHOLMOD'")
 include(CMakeDependentOption)
 option(BUILD_CXSPARSE "Build CXSparse" OFF)
 option(WITH_DEMOS "Build demos" OFF)
-option(WITH_METIS "Enables METIS support" OFF)
-option(WITH_OPENMP "Enable OpenMP support" ON)
+option(WITH_METIS "Enables METIS support" ON)
+option(WITH_OPENMP "Enable OpenMP support" OFF)
 option(WITH_PRINT "Print diagnostic messages" ON)
 option(WITH_TBB "Enables Intel Threading Building Blocks support" OFF)
 set(WITH_LICENSE "GPL" CACHE STRING "Software license the binary distribution should adhere")
@@ -93,6 +93,19 @@ function(suitesparse_import_target)
     set(HAVE_BLAS_NO_UNDERSCORE ON)
     set(HAVE_BLAS_UNDERSCORE OFF)
 
+    if(WITH_METIS AND NOT TARGET METIS::METIS)
+		# TODO: remove once we upgrade to a modern version of SuiteSparse that provides its own modified Metis.
+		# This version is configured to use 32-bit integers for compatibility
+		# with `wildmeshing-tookit` (see metis.cmake). This limits mesh sizes to
+		# a degree, but in theory SuiteSparse autmatically handles casting from
+		# the 64-bit integers passed to its `*_l_*` routines when calling METIS.
+        include(metis)
+        add_library(METIS::METIS INTERFACE IMPORTED)
+        target_link_libraries(METIS::METIS INTERFACE metis::metis)
+        set(METIS_INCLUDE_DIR "${POLYSOLVE_METIS_SOURCE_DIR}/include" CACHE PATH "" FORCE)
+        set(METIS_LIBRARY "metis::metis" CACHE STRING "" FORCE)
+    endif()
+
     # SuiteSparse is composed of multiple libraries. If LGPL is enabled, we need to build shared
     # libraries to comply with the license. If GPL is enabled, it is the user's responsibility to
     # comply with the license by release the parts of their code that depends on SuiteSparse under GPL.
@@ -106,6 +119,19 @@ function(suitesparse_import_target)
         GIT_TAG 0ba07264225518a487a0a9a8e675f6e36c96a68a
         EXCLUDE_FROM_ALL ON
     )
+
+    if(TARGET METIS::METIS)
+		# We need the METIS configuration (particularly `IDXTYPEWIDTH` and
+		# `REALTYPEWIDTH`) to propagate through to SuiteSparse's `cholmod_int` and `cholmod_long`
+		# targets to work around compilation errors.
+		# TODO: remove once we upgrade to a modern version of SuiteSparse that provides its own modified Metis.
+        foreach(name IN ITEMS cholmod_int cholmod_long)
+            if(TARGET ${name})
+                target_link_libraries(${name} PRIVATE METIS::METIS)
+            endif()
+        endforeach()
+    endif()
+
     if(WITH_LICENSE STREQUAL LGPL)
         pop_variable(BUILD_SHARED_LIBS)
     endif()

--- a/cmake/recipes/try_system_mkl.cmake
+++ b/cmake/recipes/try_system_mkl.cmake
@@ -1,0 +1,118 @@
+# Try to define mkl::mkl from an activated Intel oneAPI MKL installation;
+# this is indicated by the presence of MKL environment variables.
+# This is intentionally optional: if no MKL root is configured, it leaves
+# mkl::mkl undefined so the caller can fall back to the old CPM download route.
+
+if(TARGET mkl::mkl)
+    return()
+endif()
+
+set(MKL_ROOT "" CACHE PATH "Path to an existing Intel oneAPI MKL installation")
+if(MKL_ROOT)
+    set(_mkl_root "${MKL_ROOT}")
+elseif(DEFINED ENV{MKL_ROOT})
+    set(_mkl_root "$ENV{MKL_ROOT}")
+elseif(DEFINED ENV{MKLROOT})
+    set(_mkl_root "$ENV{MKLROOT}")
+else()
+    return()
+endif()
+
+get_filename_component(_mkl_root "${_mkl_root}" ABSOLUTE)
+
+function(_system_mkl_assert_is_found var)
+    if(NOT ${var})
+        message(FATAL_ERROR "Could not find ${var} in MKL root: ${_mkl_root}")
+    endif()
+endfunction()
+
+message(STATUS "Using system MKL from: ${_mkl_root}")
+
+find_path(MKL_INCLUDE_DIR
+    NAMES mkl.h
+    HINTS "${_mkl_root}/include"
+    NO_DEFAULT_PATH
+)
+_system_mkl_assert_is_found(MKL_INCLUDE_DIR)
+message(STATUS "MKL include dir: ${MKL_INCLUDE_DIR}")
+
+set(_mkl_lib_hints
+    "${_mkl_root}/lib/intel64"
+    "${_mkl_root}/lib"
+)
+
+if(MKL_LINKING STREQUAL static)
+    set(_mkl_type STATIC)
+else()
+    set(_mkl_type SHARED)
+endif()
+
+add_library(mkl::mkl INTERFACE IMPORTED GLOBAL)
+target_include_directories(mkl::mkl INTERFACE ${MKL_INCLUDE_DIR})
+
+function(_system_mkl_add_imported_library name)
+    string(TOUPPER mkl_${name}_library _libvar)
+    set(_old_find_library_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    if(MKL_LINKING STREQUAL static)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+    elseif(WIN32)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+    else()
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+    endif()
+    find_library(${_libvar}
+        NAMES mkl_${name}
+        HINTS ${_mkl_lib_hints}
+        NO_DEFAULT_PATH
+    )
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_old_find_library_suffixes})
+    _system_mkl_assert_is_found(${_libvar})
+    message(STATUS "Creating target mkl::${name} for lib file: ${${_libvar}}")
+
+    add_library(mkl::${name} ${_mkl_type} IMPORTED GLOBAL)
+    set_target_properties(mkl::${name} PROPERTIES
+        IMPORTED_LOCATION "${${_libvar}}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES CXX
+    )
+
+    target_link_libraries(mkl::mkl INTERFACE mkl::${name})
+endfunction()
+
+function(_system_mkl_set_static_dependencies)
+    if(NOT MKL_LINKING STREQUAL static)
+        return()
+    endif()
+
+    set(_shifted ${ARGN})
+    list(POP_FRONT _shifted _first_item)
+    list(APPEND _shifted ${_first_item})
+    foreach(_a _b IN ZIP_LISTS ARGN _shifted)
+        set_target_properties(mkl::${_a} PROPERTIES INTERFACE_LINK_LIBRARIES mkl::${_b})
+    endforeach()
+
+    set_property(TARGET mkl::${_first_item} PROPERTY IMPORTED_LINK_INTERFACE_MULTIPLICITY 4)
+endfunction()
+
+_system_mkl_add_imported_library(core)
+_system_mkl_add_imported_library(intel_${MKL_INTERFACE})
+
+if(MKL_THREADING STREQUAL sequential)
+    _system_mkl_add_imported_library(sequential)
+    _system_mkl_set_static_dependencies(core intel_${MKL_INTERFACE} sequential)
+else()
+    _system_mkl_add_imported_library(tbb_thread)
+    _system_mkl_set_static_dependencies(core intel_${MKL_INTERFACE} tbb_thread)
+    include(onetbb)
+    target_link_libraries(mkl::tbb_thread INTERFACE TBB::tbb)
+endif()
+
+if(MKL_INTERFACE STREQUAL "ilp64")
+    target_compile_definitions(mkl::mkl INTERFACE MKL_ILP64)
+endif()
+
+if(NOT MSVC)
+    find_package(Threads REQUIRED)
+    find_library(LIBM_LIBRARY m)
+    _system_mkl_assert_is_found(LIBM_LIBRARY)
+    target_link_libraries(mkl::mkl INTERFACE Threads::Threads ${LIBM_LIBRARY} ${CMAKE_DL_LIBS})
+endif()

--- a/linear-solver-spec.json
+++ b/linear-solver-spec.json
@@ -16,7 +16,8 @@
             "Pardiso",
             "Hypre",
             "AMGCL",
-            "MAS"
+            "MAS",
+            "Catamari"
         ],
         "doc": "Settings for the linear solver."
     },
@@ -42,6 +43,7 @@
             "Eigen::PardisoLU",
             "Pardiso",
             "Hypre",
+            "Catamari",
             "AMGCL",
             "Eigen::LeastSquaresConjugateGradient",
             "Eigen::DGMRES",
@@ -158,6 +160,47 @@
             "precond"
         ],
         "doc": "Settings for the AMGCL solver."
+    },
+    {
+        "pointer": "/Catamari",
+        "default": null,
+        "type": "object",
+        "optional": [
+            "ordering",
+            "use_left_looking",
+            "use_block_accel"
+        ],
+        "doc": "Settings for the Catamari solver."
+    },
+    {
+        "pointer": "/Catamari/ordering",
+        "default": "Catamari",
+        "type": "string",
+        "options": [
+            "Catamari",
+            "CholmodNesdis",
+            "Nesdis",
+            "Metis",
+            "AMD",
+            "Adaptive",
+            "Scotch",
+            "AccelerateMetis",
+            "PardisoMetis",
+            "PardisoParallelMetis"
+        ],
+        "doc": "Ordering method used by the Catamari solver."
+    },
+    {
+        "pointer": "/Catamari/use_left_looking",
+        "default": false,
+        "type": "bool",
+        "doc": "Use Catamari's left-looking supernodal algorithm."
+    },
+    {
+        "pointer": "/Catamari/use_block_accel",
+        "default": true,
+        "type": "bool",
+        "doc": "Use MeshFEMSparse's block acceleration path when available."
     },
     {
         "pointer": "/Eigen::LeastSquaresConjugateGradient/max_iter",

--- a/linear-solver-spec.json
+++ b/linear-solver-spec.json
@@ -174,7 +174,7 @@
     },
     {
         "pointer": "/Catamari/ordering",
-        "default": "Catamari",
+        "default": "Adaptive",
         "type": "string",
         "options": [
             "Catamari",

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -24,6 +24,8 @@ namespace polysolve
     struct BCSCHessianWithFixedVars {
         using BCSCHessian = MeshFEM::BlockCSCHessianBase;
         std::unique_ptr<BCSCHessian> H;
+        double reg_weight = 0.0; // Multiple of the identity to add to the Hessian during factorization (used, e.g., by `RegularizedNewton`)
+
         BCSCHessianWithFixedVars() = default;
         BCSCHessianWithFixedVars(std::unique_ptr<BCSCHessian> &&H_, const std::vector<size_t> &fixedVars_ = {})
             : H(std::move(H_)), m_fixedVars(fixedVars_) { }

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -183,7 +183,7 @@ namespace polysolve
 
             if (const auto *H_ref = std::get_if<std::reference_wrapper<const T>>(&m_value())) {
                 if constexpr (!std::is_copy_constructible_v<T>) throw std::logic_error("Cannot switch borrowed non-copyable Hessian to owned native type");
-                m_evaluated_hessian.emplace(std::in_place_type<T>, H_ref->get());
+                else m_evaluated_hessian.emplace(std::in_place_type<T>, H_ref->get());
             }
             else m_evaluated_hessian.emplace(std::in_place_type<T>, std::move(const_cast<T &>(this->as<T>())));
 

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -55,6 +55,8 @@ namespace polysolve
                 if (!m_isFixed[i]) v_full[i] = v[r++];
 
             Eigen::VectorXd result_full = H->apply(v_full);
+            if (reg_weight != 0) result_full += reg_weight * v_full;
+
             Eigen::VectorXd result(reduced_size());
             for (size_t i = 0, r = 0; i < full_size(); ++i)
                 if (!m_isFixed[i]) result[r++] = result_full[i];

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <variant>
 #include <type_traits>
+#include <functional>
 
 namespace polysolve
 {
@@ -92,16 +93,6 @@ namespace polysolve
         template <typename T>
         struct type_tag { using type = T; };
 
-        template <typename Variant>
-        struct VariantTraits;
-
-        template <typename... Ts>
-        struct VariantTraits<std::variant<Ts...>> {
-            using CacheTuple = std::tuple<std::optional<Ts>...>;
-            template <typename T>
-            static constexpr bool contains = (std::is_same_v<T, Ts> || ...);
-        };
-
         // Note: a conversion function must exist for all pairwise conversions
         // in order for the std::visit` call to be well formed. Only a few
         // conversions are actually supported/used in practice and should be
@@ -127,30 +118,59 @@ namespace polysolve
     //
     // Since the `Problem` API takes the output `Hessian` by reference rather
     // than returning it, this type is forced to start out in an "empty" state.
+    template<class... HessianTypes>
+    struct VariantTypes {
+        using Variant = std::variant<HessianTypes..., std::reference_wrapper<const HessianTypes>...>;
+        using CacheTuple = std::tuple<std::optional<HessianTypes>...>;
+
+        template<typename T>
+        static constexpr bool contains = (std::is_same_v<T, HessianTypes> || ...);
+    };
+
     struct Hessian {
         using DenseHessian = HessianConversion::DenseHessian;
-        using Variant = std::variant<StiffnessMatrix, DenseHessian, BCSCHessianWithFixedVars>;
+        using Types = VariantTypes<StiffnessMatrix, DenseHessian, BCSCHessianWithFixedVars>;
+        using Variant = typename Types::Variant;
 
         Hessian() = default;
 
-        template<typename T, std::enable_if_t<std::is_constructible_v<Variant, T &&> && !std::is_same_v<std::decay_t<T>, Hessian>, int> = 0>
+        // Warning: this constructor always performs a copy/move into a new, internally owned matrix.
+        // If a const reference to an externally owned matrix is desired, use `Hessian::borrow` instead.
+        template<typename T, std::enable_if_t<Types::template contains<std::decay_t<T>> && !std::is_same_v<std::decay_t<T>, Hessian>, int> = 0>
         Hessian(T &&H) : m_evaluated_hessian(std::in_place, std::in_place_type<std::decay_t<T>>, std::forward<T>(H)) { }
+
+        template<typename T>
+        static Hessian borrow(const T &hessian) {
+            using HessianType = std::remove_cv_t<T>;
+            static_assert(Types::template contains<HessianType>, "Unsupported Hessian representation");
+            Hessian result;
+            result.m_evaluated_hessian.emplace(std::in_place_type<std::reference_wrapper<const HessianType>>, std::cref(hessian));
+            return result;
+        }
 
         template <typename T, typename... Args>
         T &emplace(Args &&...args) {
-            static_assert(Traits::template contains<T>, "Unsupported Hessian representation");
+            static_assert(Types::template contains<T>, "Unsupported Hessian representation");
             clear_caches();
             m_evaluated_hessian.emplace(std::in_place_type<T>, std::forward<Args>(args)...);
             return std::get<T>(*m_evaluated_hessian);
         }
 
+        Hessian(const Hessian &other) = delete;            // Would require all Hessian representations to be copyable...
+        Hessian(Hessian &&other) = default;
         Hessian &operator=(const Hessian &other) = delete; // Would require all Hessian representations to be copyable...
         Hessian &operator=(Hessian &&other) = default;
 
         template<typename T>
+        static const T &unwrap(const T &H) { return H; }
+
+        template<typename T>
+        static const T &unwrap(const std::reference_wrapper<const T> &H) { return H.get(); }
+
+        template<typename T>
         T &get_mutable() {
             if (!m_evaluated_hessian) throw std::logic_error("Hessian has not been evaluated");
-            if (!std::holds_alternative<T>(*m_evaluated_hessian)) throw std::logic_error("Hessian is not of the requested type");
+            if (!std::holds_alternative<T>(*m_evaluated_hessian)) throw std::logic_error("Hessian is not of the requested non-reference type");
             if (has_cached_conversions()) throw std::logic_error("Cannot mutate Hessian after conversions have been cached; call clear_caches() first if you know this is safe (no dangling references to the cached conversions exist)");
             return std::get<T>(*m_evaluated_hessian);
         }
@@ -159,23 +179,32 @@ namespace polysolve
         // cached conversions.
         template<typename T>
         void switch_to_native_type() {
-            if (is_native_type<T>()) return; // Already in the requested type
-            m_evaluated_hessian.emplace(std::in_place_type<T>, std::move(const_cast<T &>(this->as<T>())));
+            if (std::holds_alternative<T>(m_value())) return; // Already owning the requested type
+
+            if (const auto *H_ref = std::get_if<std::reference_wrapper<const T>>(&m_value())) {
+                if constexpr (!std::is_copy_constructible_v<T>) throw std::logic_error("Cannot switch borrowed non-copyable Hessian to owned native type");
+                m_evaluated_hessian.emplace(std::in_place_type<T>, H_ref->get());
+            }
+            else m_evaluated_hessian.emplace(std::in_place_type<T>, std::move(const_cast<T &>(this->as<T>())));
+
             clear_caches();
         }
 
         template<typename T>
         const T &as() const {
-            static_assert(Traits::template contains<T>, "T is not one of the supported Hessian representations");
+            static_assert(Types::template contains<T>, "T is not one of the supported Hessian representations");
 
             if (const auto *H = std::get_if<T>(&m_value()))
                 return *H;
+
+            if (const auto *H = std::get_if<std::reference_wrapper<const T>>(&m_value()))
+                return H->get();
 
             auto &cache = std::get<std::optional<T>>(m_conversion_caches);
 
             if (!cache) {
                 cache.emplace(std::visit(
-                    [](const auto &source) -> T { return HessianConversion::convert(HessianConversion::type_tag<T>{}, source); },
+                    [](const auto &source) -> T { return HessianConversion::convert(HessianConversion::type_tag<T>{}, unwrap(source)); },
                     m_value()));
             }
 
@@ -190,13 +219,13 @@ namespace polysolve
         template <typename T>
         bool is_native_type() const noexcept {
             if (!m_evaluated_hessian) return false;
-            static_assert(Traits::template contains<T>, "T is not one of the supported Hessian representations");
+            static_assert(Types::template contains<T>, "T is not one of the supported Hessian representations");
             return std::holds_alternative<T>(m_value());
         }
 
-        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const { return std::visit([&v](const auto &H) -> Eigen::VectorXd { return H * v; }, m_value()); }
-        Eigen::Index rows() const { return std::visit([](const auto &H) -> Eigen::Index { return H.rows(); }, m_value()); }
-        Eigen::Index cols() const { return std::visit([](const auto &H) -> Eigen::Index { return H.cols(); }, m_value()); }
+        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const { return std::visit([&v](const auto &H) -> Eigen::VectorXd { return unwrap(H) * v; }, m_value()); }
+        Eigen::Index rows() const { return std::visit([](const auto &H) -> Eigen::Index { return unwrap(H).rows(); }, m_value()); }
+        Eigen::Index cols() const { return std::visit([](const auto &H) -> Eigen::Index { return unwrap(H).cols(); }, m_value()); }
 
         // Empty state management
         bool has_value() const noexcept { return m_evaluated_hessian.has_value(); }
@@ -213,8 +242,7 @@ namespace polysolve
         void clear_caches() const { std::apply([](auto &...cache) { (cache.reset(), ...); }, m_conversion_caches); }
         bool has_cached_conversions() const { return std::apply([](const auto &...cache) { return (... || cache.has_value()); }, m_conversion_caches); }
 
-        using Traits = HessianConversion::VariantTraits<Variant>;
-        using Caches = typename Traits::CacheTuple;
+        using Caches = typename Types::CacheTuple;
 
         std::optional<Variant> m_evaluated_hessian;
         mutable Caches m_conversion_caches; // Caches of converted Hessians.

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -24,25 +24,62 @@ namespace polysolve
     struct BCSCHessianWithFixedVars {
         using BCSCHessian = MeshFEM::BlockCSCHessianBase;
         std::unique_ptr<BCSCHessian> H;
-        std::vector<size_t> fixedVars;
-
         BCSCHessianWithFixedVars() = default;
         BCSCHessianWithFixedVars(std::unique_ptr<BCSCHessian> &&H_, const std::vector<size_t> &fixedVars_ = {})
-            : H(std::move(H_)), fixedVars(fixedVars_) { }
+            : H(std::move(H_)), m_fixedVars(fixedVars_) { }
 
-        static BCSCHessianWithFixedVars fromEigen(const StiffnessMatrix &H_eigen, const std::vector<size_t> &fixedVars = {}) {
-            return BCSCHessianWithFixedVars{BCSCHessian::fromEigen(H_eigen), fixedVars};
+        static BCSCHessianWithFixedVars fromEigen(const StiffnessMatrix &H_eigen) {
+            return BCSCHessianWithFixedVars{BCSCHessian::fromEigen(H_eigen)};
         }
 
-        StiffnessMatrix toEigen() const { return H->template toEigen<StiffnessMatrix::StorageIndex>(/* upperTriangleOnly = */ false, fixedVars); }
+        StiffnessMatrix toEigen() const { return H->template toEigen<StiffnessMatrix::StorageIndex>(/* upperTriangleOnly = */ false, m_fixedVars); }
+
+        size_t full_size() const { return H->numScalarCols(); }
+        // WARNING: assumes all fixedVars are unique and in-bounds!
+        // We currently don't validate this here because it is already validated within PolyFEM.
+        size_t reduced_size() const { return full_size() - m_fixedVars.size(); }
 
         // Basic "duck typing" compatibility with Eigen matrix types.
-        size_t rows() const { return H->numScalarCols(); }
-        size_t cols() const { return H->numScalarCols(); }
+        size_t rows() const { return reduced_size(); }
+        size_t cols() const { return reduced_size(); }
         Eigen::VectorXd operator*(const Eigen::VectorXd &v) const {
-            if (fixedVars.empty())  return H->apply(v);
-            throw std::runtime_error("BCSCHessianWithFixedVars::operator* not yet implemented for nonempty fixedVars");
+            if (m_fixedVars.empty()) return H->apply(v);
+
+            m_buildFixedMask();
+            if (size_t(v.size()) != reduced_size()) throw std::runtime_error("BCSCHessianWithFixedVars::operator*: incorrect reduced vector size");
+
+            Eigen::VectorXd v_full = Eigen::VectorXd::Zero(full_size());
+            for (size_t i = 0, r = 0; i < full_size(); ++i)
+                if (!m_isFixed[i]) v_full[i] = v[r++];
+
+            Eigen::VectorXd result_full = H->apply(v_full);
+            Eigen::VectorXd result(reduced_size());
+            for (size_t i = 0, r = 0; i < full_size(); ++i)
+                if (!m_isFixed[i]) result[r++] = result_full[i];
+            return result;
         }
+
+        const std::vector<size_t> &fixedVars() const { return m_fixedVars; }
+
+        template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+        void setFixedVars(const std::vector<T> &fv) {
+            m_fixedVars = std::vector<size_t>(fv.begin(), fv.end()); // Potential integer type conversion...
+            m_isFixed.clear();
+        }
+
+    private:
+        void m_buildFixedMask() const {
+            if (m_isFixed.size() == full_size()) return;
+            m_isFixed.resize(full_size(), false);
+            for (size_t i : m_fixedVars) {
+                if (i >= full_size()) throw std::runtime_error("BCSCHessianWithFixedVars::buildFixedMask: fixed variable index out of bounds");
+                if (m_isFixed[i])     throw std::runtime_error("BCSCHessianWithFixedVars::buildFixedMask: duplicate fixed variable index");
+                m_isFixed[i] = true;
+            }
+        }
+
+        std::vector<size_t> m_fixedVars;
+        mutable std::vector<bool> m_isFixed;
     };
 
     struct HessianConversion {

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -111,13 +111,9 @@ namespace polysolve
         }
 
         // Supported Hessian conversions
-        // static Eigen::MatrixXd convert(type_tag<Eigen::MatrixXd>, const StiffnessMatrix &H) { return Eigen::MatrixXd(H); } // To dense
-
-        // TODO: this conversion can be avoided once MeshFEMSparse updates its
-        // `CatamariFactorizer` wrapper to support Eigen sparse matrices natively.
-        static BCSCHessianWithFixedVars convert(type_tag<BCSCHessianWithFixedVars>, const StiffnessMatrix &H) { return BCSCHessianWithFixedVars::fromEigen(H); }
-        static StiffnessMatrix          convert(type_tag<StiffnessMatrix>, const BCSCHessianWithFixedVars &H) { return H.toEigen(); }
-        static DenseHessian             convert(type_tag<DenseHessian>,    const BCSCHessianWithFixedVars &H) { return DenseHessian(H.toEigen()); } // TODO: Avoid double-conversion?
+        static BCSCHessianWithFixedVars convert(type_tag<BCSCHessianWithFixedVars>, const StiffnessMatrix &H) { return BCSCHessianWithFixedVars::fromEigen(H); } // TODO: this conversion can be avoided once MeshFEMSparse updates its `CatamariFactorizer` wrapper to support Eigen sparse matrices natively.
+        static StiffnessMatrix          convert(type_tag<StiffnessMatrix>, const BCSCHessianWithFixedVars &H) { StiffnessMatrix K = H.toEigen(); if (H.reg_weight != 0.0) { K.diagonal().array() += H.reg_weight; } return K; }
+        static DenseHessian             convert(type_tag<DenseHessian>,    const BCSCHessianWithFixedVars &H) { DenseHessian    D = H.toEigen(); if (H.reg_weight != 0.0) { D.diagonal().array() += H.reg_weight; } return D; } // TODO: Avoid double-conversion?
         static DenseHessian             convert(type_tag<DenseHessian>,    const          StiffnessMatrix &H) { return DenseHessian(H); }
     };
 

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -1,0 +1,180 @@
+// Support for various Hessian representations and conversions between them.
+#pragma once
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+#include <MeshFEMSparse/BlockCSCHessian.hh>
+
+#include <optional>
+#include <variant>
+#include <type_traits>
+
+namespace polysolve
+{
+    // The Catamari solver can implement pin constraints more efficiently than
+    // performing an explicit slicing operation. We therefore provide this
+    // wrapper type to enable the pinned variables to be communicated directly
+    // to the solver that support them.
+    //
+    // When fixed variables are present, solves are done in the reduced space
+    // (i.e., the user's right-hand side and the returned solution
+    // will both be of size `rows() - nfv`, where `nfv` is the number of
+    // unique indices in `fixedVars). This differs from MeshFEMSparse's
+    // convention of working with full-space RHS and solution vectors.
+    struct BCSCHessianWithFixedVars {
+        using BCSCHessian = MeshFEM::BlockCSCHessianBase;
+        std::unique_ptr<BCSCHessian> H;
+        std::vector<size_t> fixedVars;
+
+        BCSCHessianWithFixedVars() = default;
+        BCSCHessianWithFixedVars(std::unique_ptr<BCSCHessian> &&H_, const std::vector<size_t> &fixedVars_ = {})
+            : H(std::move(H_)), fixedVars(fixedVars_) { }
+
+        static BCSCHessianWithFixedVars fromEigen(const StiffnessMatrix &H_eigen, const std::vector<size_t> &fixedVars = {}) {
+            return BCSCHessianWithFixedVars{BCSCHessian::fromEigen(H_eigen), fixedVars};
+        }
+
+        StiffnessMatrix toEigen() const { return H->template toEigen<StiffnessMatrix::StorageIndex>(/* upperTriangleOnly = */ false, fixedVars); }
+
+        // Basic "duck typing" compatibility with Eigen matrix types.
+        size_t rows() const { return H->numScalarCols(); }
+        size_t cols() const { return H->numScalarCols(); }
+        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const {
+            if (fixedVars.empty())  return H->apply(v);
+            throw std::runtime_error("BCSCHessianWithFixedVars::operator* not yet implemented for nonempty fixedVars");
+        }
+    };
+
+    struct HessianConversion {
+        using DenseHessian = Eigen::MatrixXd;
+
+        template <typename T>
+        struct type_tag { using type = T; };
+
+        template <typename Variant>
+        struct VariantTraits;
+
+        template <typename... Ts>
+        struct VariantTraits<std::variant<Ts...>> {
+            using CacheTuple = std::tuple<std::optional<Ts>...>;
+            template <typename T>
+            static constexpr bool contains = (std::is_same_v<T, Ts> || ...);
+        };
+
+        // Note: a conversion function must exist for all pairwise conversions
+        // in order for the std::visit` call to be well formed. Only a few
+        // conversions are actually supported/used in practice and should be
+        // implemented as type-specific overloads. Identity conversions are
+        // unnecessary since the initial `get_if<T>` attempt will succeed when
+        // source and target conversion types coincide.
+        template<class T_dst, class T_src> static T_dst convert(type_tag<T_dst>, const T_src &/* H */) {
+            throw std::runtime_error("Hessian conversion not supported from " + std::string(typeid(T_src).name()) + " to " + std::string(typeid(T_dst).name()));
+        }
+
+        // Supported Hessian conversions
+        // static Eigen::MatrixXd convert(type_tag<Eigen::MatrixXd>, const StiffnessMatrix &H) { return Eigen::MatrixXd(H); } // To dense
+
+        // TODO: this conversion can be avoided once MeshFEMSparse updates its
+        // `CatamariFactorizer` wrapper to support Eigen sparse matrices natively.
+        static BCSCHessianWithFixedVars convert(type_tag<BCSCHessianWithFixedVars>, const StiffnessMatrix &H) { return BCSCHessianWithFixedVars::fromEigen(H); }
+        static StiffnessMatrix          convert(type_tag<StiffnessMatrix>, const BCSCHessianWithFixedVars &H) { return H.toEigen(); }
+        static DenseHessian             convert(type_tag<DenseHessian>,    const BCSCHessianWithFixedVars &H) { return DenseHessian(H.toEigen()); } // TODO: Avoid double-conversion?
+        static DenseHessian             convert(type_tag<DenseHessian>,    const          StiffnessMatrix &H) { return DenseHessian(H); }
+    };
+
+    // Stores one of a number of possible Hessian types and facilitates
+    // conversion into other types.
+    // This is intended as a lightweight adapter class to interface between Hessian
+    // evaluation routines, which evaluate in their preferred format, and
+    // solver routines that accept only certain formats.
+    //
+    // Since the `Problem` API takes the output `Hessian` by reference rather
+    // than returning it, this type is forced to start out in an "empty" state.
+    struct Hessian {
+        using DenseHessian = HessianConversion::DenseHessian;
+        using Variant = std::variant<StiffnessMatrix, DenseHessian, BCSCHessianWithFixedVars>;
+
+        Hessian() = default;
+
+        template<typename T, std::enable_if_t<std::is_constructible_v<Variant, T &&> && !std::is_same_v<std::decay_t<T>, Hessian>, int> = 0>
+        Hessian(T &&H) : m_evaluated_hessian(std::in_place, std::in_place_type<std::decay_t<T>>, std::forward<T>(H)) { }
+
+        template <typename T, typename... Args>
+        T &emplace(Args &&...args) {
+            static_assert(Traits::template contains<T>, "Unsupported Hessian representation");
+            clear_caches();
+            m_evaluated_hessian.emplace(std::in_place_type<T>, std::forward<Args>(args)...);
+            return std::get<T>(*m_evaluated_hessian);
+        }
+
+        Hessian &operator=(const Hessian &other) = delete; // Would require all Hessian representations to be copyable...
+        Hessian &operator=(Hessian &&other) = default;
+
+        template<typename T>
+        T &get_mutable() {
+            if (!m_evaluated_hessian) throw std::logic_error("Hessian has not been evaluated");
+            if (!std::holds_alternative<T>(*m_evaluated_hessian)) throw std::logic_error("Hessian is not of the requested type");
+            if (has_cached_conversions()) throw std::logic_error("Cannot mutate Hessian after conversions have been cached; call clear_caches() first if you know this is safe (no dangling references to the cached conversions exist)");
+            return std::get<T>(*m_evaluated_hessian);
+        }
+
+        // Replace m_evaluated_hessian with a new value of type T, clearing any
+        // cached conversions.
+        template<typename T>
+        void switch_to_native_type() {
+            if (is_native_type<T>()) return; // Already in the requested type
+            m_evaluated_hessian.emplace(std::in_place_type<T>, std::move(const_cast<T &>(this->as<T>())));
+            clear_caches();
+        }
+
+        template<typename T>
+        const T &as() const {
+            static_assert(Traits::template contains<T>, "T is not one of the supported Hessian representations");
+
+            if (const auto *H = std::get_if<T>(&m_value()))
+                return *H;
+
+            auto &cache = std::get<std::optional<T>>(m_conversion_caches);
+
+            if (!cache) {
+                cache.emplace(std::visit(
+                    [](const auto &source) -> T { return HessianConversion::convert(HessianConversion::type_tag<T>{}, source); },
+                    m_value()));
+            }
+
+            return *cache;
+        }
+
+        template <typename T>
+        bool is_native_type() const noexcept {
+            if (!m_evaluated_hessian) return false;
+            static_assert(Traits::template contains<T>, "T is not one of the supported Hessian representations");
+            return std::holds_alternative<T>(m_value());
+        }
+
+        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const { return std::visit([&v](const auto &H) -> Eigen::VectorXd { return H * v; }, m_value()); }
+        Eigen::Index rows() const { return std::visit([](const auto &H) -> Eigen::Index { return H.rows(); }, m_value()); }
+        Eigen::Index cols() const { return std::visit([](const auto &H) -> Eigen::Index { return H.cols(); }, m_value()); }
+
+        // Empty state management
+        bool has_value() const noexcept { return m_evaluated_hessian.has_value(); }
+        explicit operator bool() const noexcept { return has_value(); }
+        void reset() noexcept { m_evaluated_hessian.reset(); clear_caches(); }
+    private:
+        const Variant &m_value() const {
+            if (!m_evaluated_hessian)
+                throw std::logic_error("Hessian has not been evaluated");
+            return *m_evaluated_hessian;
+        }
+
+        Variant &m_value() { return const_cast<Variant &>(static_cast<const Hessian &>(*this).m_value()); }
+        void clear_caches() const { std::apply([](auto &...cache) { (cache.reset(), ...); }, m_conversion_caches); }
+        bool has_cached_conversions() const { return std::apply([](const auto &...cache) { return (... || cache.has_value()); }, m_conversion_caches); }
+
+        using Traits = HessianConversion::VariantTraits<Variant>;
+        using Caches = typename Traits::CacheTuple;
+
+        std::optional<Variant> m_evaluated_hessian;
+        mutable Caches m_conversion_caches; // Caches of converted Hessians.
+    };
+} // namespace polysolve

--- a/src/polysolve/Hessian.hpp
+++ b/src/polysolve/Hessian.hpp
@@ -180,6 +180,11 @@ namespace polysolve
             return *cache;
         }
 
+        // Support "casting" to dense Hessian for duck typing with Eigen matrix types.
+        // This should essentially never be used in practice (and hence is guarded by `explicit`),
+        // however it is currently needed to build the unit tests.
+        explicit operator const Eigen::MatrixXd &() const { return as<DenseHessian>(); }
+
         template <typename T>
         bool is_native_type() const noexcept {
             if (!m_evaluated_hessian) return false;

--- a/src/polysolve/Types.hpp
+++ b/src/polysolve/Types.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
-#include <Eigen/Dense>
 #include <Eigen/Sparse>
-
 #include <nlohmann/json.hpp>
-#include <MeshFEM/newton_optimizer/NewtonHessian.hh>
-
-#include <variant>
 
 namespace polysolve
 {
@@ -18,51 +13,6 @@ namespace polysolve
 #endif
 
     using json = nlohmann::json;
-
-    struct Hessian {
-        using Variant = std::variant<StiffnessMatrix, Eigen::MatrixXd, NewtonHessian>;
-        Variant evaluated_hessian;
-
-        template<typename T>
-        explicit Hessian(std::in_place_type_t<T>) : evaluated_hessian(std::in_place_type<T>) {}
-
-
-        template<typename T>
-        T &get() {
-            T *H = std::get_if<T>(&evaluated_hessian);
-            if (H) return *H;
-            throw std::runtime_error("Hessian does not hold the requested type");
-        }
-
-        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const {
-            if (const auto *H = std::get_if<StiffnessMatrix>(&evaluated_hessian)) return *H * v;
-            if (const auto *H = std::get_if<Eigen::MatrixXd>(&evaluated_hessian))  return *H * v;
-            if (const auto *H = std::get_if<NewtonHessian>(&evaluated_hessian))    return H->apply(v);
-            throw std::runtime_error("Unknown Hessian type");
-        }
-    
-
-        template<typename T>
-        const T &get() const {
-            const T *H = std::get_if<T>(&evaluated_hessian);
-            if (H) return *H;
-
-            converted_hessian = Variant(std::in_place_type<T>);
-            auto &H_c = std::get<T>(converted_hessian);
-
-            return H_c;
-        }
-
-        Eigen::Index rows() const {
-            if (const auto *H = std::get_if<NewtonHessian>(&converted_hessian))    return static_cast<Eigen::Index>(H->numVars());
-            else if (const auto *H = std::get_if<StiffnessMatrix>(&converted_hessian)) return H->rows();
-            else if (const auto *H = std::get_if<Eigen::MatrixXd>(&converted_hessian)) return H->rows();
-            throw std::runtime_error("Unknown Hessian type");
-        }
-
-        
-    private:
-        mutable Variant converted_hessian;
-    };
-
 } // namespace polysolve
+
+#include "Hessian.hpp"

--- a/src/polysolve/Types.hpp
+++ b/src/polysolve/Types.hpp
@@ -4,6 +4,9 @@
 #include <Eigen/Sparse>
 
 #include <nlohmann/json.hpp>
+#include <MeshFEM/newton_optimizer/NewtonHessian.hh>
+
+#include <variant>
 
 namespace polysolve
 {
@@ -15,5 +18,51 @@ namespace polysolve
 #endif
 
     using json = nlohmann::json;
+
+    struct Hessian {
+        using Variant = std::variant<StiffnessMatrix, Eigen::MatrixXd, NewtonHessian>;
+        Variant evaluated_hessian;
+
+        template<typename T>
+        explicit Hessian(std::in_place_type_t<T>) : evaluated_hessian(std::in_place_type<T>) {}
+
+
+        template<typename T>
+        T &get() {
+            T *H = std::get_if<T>(&evaluated_hessian);
+            if (H) return *H;
+            throw std::runtime_error("Hessian does not hold the requested type");
+        }
+
+        Eigen::VectorXd operator*(const Eigen::VectorXd &v) const {
+            if (const auto *H = std::get_if<StiffnessMatrix>(&evaluated_hessian)) return *H * v;
+            if (const auto *H = std::get_if<Eigen::MatrixXd>(&evaluated_hessian))  return *H * v;
+            if (const auto *H = std::get_if<NewtonHessian>(&evaluated_hessian))    return H->apply(v);
+            throw std::runtime_error("Unknown Hessian type");
+        }
+    
+
+        template<typename T>
+        const T &get() const {
+            const T *H = std::get_if<T>(&evaluated_hessian);
+            if (H) return *H;
+
+            converted_hessian = Variant(std::in_place_type<T>);
+            auto &H_c = std::get<T>(converted_hessian);
+
+            return H_c;
+        }
+
+        Eigen::Index rows() const {
+            if (const auto *H = std::get_if<NewtonHessian>(&converted_hessian))    return static_cast<Eigen::Index>(H->numVars());
+            else if (const auto *H = std::get_if<StiffnessMatrix>(&converted_hessian)) return H->rows();
+            else if (const auto *H = std::get_if<Eigen::MatrixXd>(&converted_hessian)) return H->rows();
+            throw std::runtime_error("Unknown Hessian type");
+        }
+
+        
+    private:
+        mutable Variant converted_hessian;
+    };
 
 } // namespace polysolve

--- a/src/polysolve/linear/AMGCL.cpp
+++ b/src/polysolve/linear/AMGCL.cpp
@@ -159,7 +159,7 @@ namespace polysolve::linear
         }
         assert(precond_num_ > 0);
 
-        auto &Ain = H.get<StiffnessMatrix>();
+        const auto &Ain = H.as<StiffnessMatrix>();
 
         int numRows = Ain.rows();
 
@@ -247,7 +247,7 @@ namespace polysolve::linear
     template <int BLOCK_SIZE>
     void AMGCL_Block<BLOCK_SIZE>::factorize(const Hessian &H)
     {
-        auto &Ain = H.get<StiffnessMatrix>();
+        const auto &Ain = H.as<StiffnessMatrix>();
         assert(precond_num_ > 0);
 
         int numRows = Ain.rows();

--- a/src/polysolve/linear/AMGCL.cpp
+++ b/src/polysolve/linear/AMGCL.cpp
@@ -145,19 +145,21 @@ namespace polysolve::linear
 
     ////////////////////////////////////////////////////////////////////////////////
 
-    void AMGCL::factorize(const StiffnessMatrix &Ain)
+    void AMGCL::factorize(const Hessian &H)
     {
         if (block_size_ == 2)
         {
-            block2_solver_.factorize(Ain);
+            block2_solver_.factorize(H);
             return;
         }
         else if (block_size_ == 3)
         {
-            block3_solver_.factorize(Ain);
+            block3_solver_.factorize(H);
             return;
         }
         assert(precond_num_ > 0);
+
+        auto &Ain = H.get<StiffnessMatrix>();
 
         int numRows = Ain.rows();
 
@@ -243,8 +245,9 @@ namespace polysolve::linear
     ////////////////////////////////////////////////////////////////////////////////
 
     template <int BLOCK_SIZE>
-    void AMGCL_Block<BLOCK_SIZE>::factorize(const StiffnessMatrix &Ain)
+    void AMGCL_Block<BLOCK_SIZE>::factorize(const Hessian &H)
     {
+        auto &Ain = H.get<StiffnessMatrix>();
         assert(precond_num_ > 0);
 
         int numRows = Ain.rows();

--- a/src/polysolve/linear/AMGCL.hpp
+++ b/src/polysolve/linear/AMGCL.hpp
@@ -68,10 +68,10 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override { precond_num_ = precond_num; }
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { precond_num_ = precond_num; }
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system Ax = b
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;
@@ -119,23 +119,23 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override
         {
             if (block_size_ == 2)
             {
-                block2_solver_.analyze_pattern(A, precond_num);
+                block2_solver_.analyze_pattern(H, precond_num);
                 return;
             }
             else if (block_size_ == 3)
             {
-                block3_solver_.analyze_pattern(A, precond_num);
+                block3_solver_.analyze_pattern(H, precond_num);
                 return;
             }
             precond_num_ = precond_num;
         }
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system Ax = b
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/AMGCL.hpp
+++ b/src/polysolve/linear/AMGCL.hpp
@@ -67,6 +67,10 @@ namespace polysolve::linear
         // Retrieve information
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &H, const int precond_num) override { precond_num_ = precond_num; }
 
@@ -117,6 +121,10 @@ namespace polysolve::linear
 
         // Retrieve information
         virtual void get_info(json &params) const override;
+
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
 
         // Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &H, const int precond_num) override

--- a/src/polysolve/linear/CMakeLists.txt
+++ b/src/polysolve/linear/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SOURCES
     Solver.hpp
     AMGCL.cpp
     AMGCL.hpp
+    CatamariSolver.cpp
+    CatamariSolver.hpp
     CuSolverDN.cu
     CuSolverDN.cuh
     EigenSolver.hpp

--- a/src/polysolve/linear/CatamariSolver.cpp
+++ b/src/polysolve/linear/CatamariSolver.cpp
@@ -59,7 +59,8 @@ namespace polysolve::linear
         const HessianType &A = H.as<HessianType>();
         if (!factorizer_.hasFactorization(FactorizationType::Symbolic) || factorizer_.wantsSymbolicFactorizationRecompute())
             analyze_pattern(H, 0);
-        factorizer_.factorizeNumeric(*A.H);
+        if (A.reg_weight != 0.0) factorizer_.factorizeNumericWithShift(*A.H, A.reg_weight);
+        else                     factorizer_.factorizeNumeric(*A.H);
     }
 
     void CatamariSolver::solve(const Ref<const VectorXd> rhs, Ref<VectorXd> result)

--- a/src/polysolve/linear/CatamariSolver.cpp
+++ b/src/polysolve/linear/CatamariSolver.cpp
@@ -1,0 +1,74 @@
+#include "CatamariSolver.hpp"
+
+#include <stdexcept>
+
+namespace polysolve::linear
+{
+
+#if MESHFEM_WITH_CATAMARI
+    CatamariSolver::CatamariSolver() = default;
+
+    MeshFEM::CatamariFactorizer::OrderingMethod CatamariSolver::ordering_from_string(const std::string &ordering)
+    {
+        using OrderingMethod = MeshFEM::CatamariFactorizer::OrderingMethod;
+
+        if (ordering == "Catamari")             return OrderingMethod::Catamari;
+        if (ordering == "CholmodNesdis")        return OrderingMethod::CholmodNesdis;
+        if (ordering == "Nesdis")               return OrderingMethod::CholmodNesdis;
+        if (ordering == "Metis")                return OrderingMethod::Metis;
+        if (ordering == "AMD")                  return OrderingMethod::AMD;
+        if (ordering == "Adaptive")             return OrderingMethod::Adaptive;
+        if (ordering == "Scotch")               return OrderingMethod::Scotch;
+        if (ordering == "AccelerateMetis")      return OrderingMethod::AccelerateMetis;
+        if (ordering == "PardisoMetis")         return OrderingMethod::PardisoMetis;
+        if (ordering == "PardisoParallelMetis") return OrderingMethod::PardisoParallelMetis;
+
+        throw std::runtime_error("Unknown Catamari ordering method: " + ordering);
+    }
+
+    void CatamariSolver::set_parameters(const json &params)
+    {
+        if (!params.contains("Catamari")) return;
+        const json &catamari_params = params["Catamari"];
+        if (catamari_params.contains("ordering"))         factorizer_.orderingMethod = ordering_from_string(catamari_params["ordering"].get<std::string>());
+        if (catamari_params.contains("use_left_looking")) factorizer_.setUseLeftLooking(catamari_params["use_left_looking"].get<bool>());
+        if (catamari_params.contains("use_block_accel"))  factorizer_.setUseBlockAccel(catamari_params["use_block_accel"].get<bool>());
+    }
+
+    void CatamariSolver::get_info(json &params) const
+    {
+        params["solver"] = name();
+        params["reduced_size"] = reduced_size_;
+        params["full_size"] = full_size_;
+        if (symbolic_factorization_) {
+            params["factor_nnz"] = factorizer_.getFactorNNZ();
+            params["flop_estimate"] = factorizer_.getFlopEstimate();
+        }
+    }
+
+    void CatamariSolver::analyze_pattern(const Hessian &H, const int)
+    {
+        const HessianType &A = H.as<HessianType>();
+        factorizer_.factorizeSymbolic(*A.H, A.fixedVars());
+        reduced_size_ = static_cast<Eigen::Index>(factorizer_.n_reduced());
+        full_size_ = static_cast<Eigen::Index>(factorizer_.n());
+    }
+
+    void CatamariSolver::factorize(const Hessian &H)
+    {
+        const HessianType &A = H.as<HessianType>();
+        if (!factorizer_.hasFactorization(FactorizationType::Symbolic) || factorizer_.wantsSymbolicFactorizationRecompute())
+            analyze_pattern(H, 0);
+        factorizer_.factorizeNumeric(*A.H);
+    }
+
+    void CatamariSolver::solve(const Ref<const VectorXd> rhs, Ref<VectorXd> result)
+    {
+        if (   rhs.size() != reduced_size_) throw std::runtime_error("[Catamari] Incorrect RHS size: expected "    + std::to_string(reduced_size_) + ", got " + std::to_string(rhs.size()));
+        if (result.size() != reduced_size_) throw std::runtime_error("[Catamari] Incorrect result size: expected " + std::to_string(reduced_size_) + ", got " + std::to_string(result.size()));
+
+        factorizer_.solveRawReduced(rhs.data(), result.data());
+    }
+#endif
+
+} // namespace polysolve::linear

--- a/src/polysolve/linear/CatamariSolver.hpp
+++ b/src/polysolve/linear/CatamariSolver.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Solver.hpp"
+
+#include <MeshFEMSparse/Solvers/CatamariFactorizer.hh>
+
+namespace polysolve::linear
+{
+
+#if MESHFEM_WITH_CATAMARI
+    class CatamariSolver final : public Solver
+    {
+    public:
+        CatamariSolver();
+
+        POLYSOLVE_DELETE_MOVE_COPY(CatamariSolver)
+
+        void set_parameters(const json &params) override;
+        void get_info(json &params) const override;
+
+        void analyze_pattern(const Hessian &H, const int precond_num) override;
+        void factorize(const Hessian &H) override;
+        void solve(const Ref<const VectorXd> rhs, Ref<VectorXd> result) override;
+
+        std::string name() const override { return "Catamari"; }
+
+    private:
+        using HessianType = polysolve::BCSCHessianWithFixedVars;
+        using FactorizationType = MeshFEM::CholeskyFactorizerBase::FactorizationType;
+
+        static MeshFEM::CatamariFactorizer::OrderingMethod ordering_from_string(const std::string &ordering);
+
+        MeshFEM::CatamariFactorizer factorizer_;
+        Eigen::Index reduced_size_ = -1;
+        Eigen::Index full_size_ = -1;
+        bool symbolic_factorization_ = false;
+    };
+#endif
+
+} // namespace polysolve::linear

--- a/src/polysolve/linear/CatamariSolver.hpp
+++ b/src/polysolve/linear/CatamariSolver.hpp
@@ -18,6 +18,10 @@ namespace polysolve::linear
         void set_parameters(const json &params) override;
         void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         void analyze_pattern(const Hessian &H, const int precond_num) override;
         void factorize(const Hessian &H) override;
         void solve(const Ref<const VectorXd> rhs, Ref<VectorXd> result) override;

--- a/src/polysolve/linear/CuSolverDN.cu
+++ b/src/polysolve/linear/CuSolverDN.cu
@@ -111,9 +111,11 @@ namespace polysolve::linear
     }
 
     template <typename T>
-    void CuSolverDN<T>::factorize(const StiffnessMatrix &A)
+    void CuSolverDN<T>::factorize(const Hessian &H)
     {
-        factorize_dense(Eigen::MatrixXd(A));
+        // Note that `factorize` vs `factorize_dense` methods can be unified
+        // now that `Hessian` is a variant type.
+        factorize_dense(H.as<Eigen::MatrixXd>());
     }
 
     template <typename T>

--- a/src/polysolve/linear/CuSolverDN.cuh
+++ b/src/polysolve/linear/CuSolverDN.cuh
@@ -37,7 +37,7 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Factorize system matrix (sparse)
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Factorize system matrix (dense, preferred)
         virtual void factorize_dense(const Eigen::MatrixXd &A) override;

--- a/src/polysolve/linear/EigenSolver.hpp
+++ b/src/polysolve/linear/EigenSolver.hpp
@@ -31,16 +31,10 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { analyze_pattern(H.as<StiffnessMatrix>(), precond_num); }
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override;
 
         // Factorize system matrix
-        virtual void factorize(const Hessian &H) override { factorize(H.as<StiffnessMatrix>()); }
-
-        // Overloads for this solver's native `StiffnessMatrix` type.
-        // Calling these raw implementation methods directly can avoid the
-        // overhead of an extra variant-induced copy.
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/EigenSolver.hpp
+++ b/src/polysolve/linear/EigenSolver.hpp
@@ -31,10 +31,16 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const Hessian &H, const int precond_num) override;
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { analyze_pattern(H.as<StiffnessMatrix>(), precond_num); }
 
         // Factorize system matrix
-        virtual void factorize(const Hessian &H) override;
+        virtual void factorize(const Hessian &H) override { factorize(H.as<StiffnessMatrix>()); }
+
+        // Overloads for this solver's native `StiffnessMatrix` type.
+        // Calling these raw implementation methods directly can avoid the
+        // overhead of an extra variant-induced copy.
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
+        virtual void factorize(const StiffnessMatrix &A) override;
 
         // Solve the linear system
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;
@@ -74,9 +80,15 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { analyze_pattern(H.as<StiffnessMatrix>(), precond_num); }
 
         // Factorize system matrix
+        virtual void factorize(const Hessian &H) override { factorize(H.as<StiffnessMatrix>()); }
+
+        // Overloads for this solver's native `StiffnessMatrix` type.
+        // Calling these raw implementation methods directly can avoid the
+        // overhead of an extra variant-induced copy.
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
         virtual void factorize(const StiffnessMatrix &A) override;
 
         // Solve the linear system

--- a/src/polysolve/linear/EigenSolver.hpp
+++ b/src/polysolve/linear/EigenSolver.hpp
@@ -31,10 +31,10 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override;
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/EigenSolver.hpp
+++ b/src/polysolve/linear/EigenSolver.hpp
@@ -30,6 +30,10 @@ namespace polysolve::linear
         // Get info on the last solve step
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &H, const int precond_num) override;
 
@@ -73,17 +77,15 @@ namespace polysolve::linear
         // Get info on the last solve step
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { analyze_pattern(H.as<StiffnessMatrix>(), precond_num); }
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override;
 
         // Factorize system matrix
-        virtual void factorize(const Hessian &H) override { factorize(H.as<StiffnessMatrix>()); }
-
-        // Overloads for this solver's native `StiffnessMatrix` type.
-        // Calling these raw implementation methods directly can avoid the
-        // overhead of an extra variant-induced copy.
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;
@@ -116,8 +118,12 @@ namespace polysolve::linear
         // Get info on the last solve step
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &A) override;
 
         // Factorize system matrix
         virtual void factorize_dense(const Eigen::MatrixXd &A) override;

--- a/src/polysolve/linear/EigenSolver.tpp
+++ b/src/polysolve/linear/EigenSolver.tpp
@@ -35,15 +35,17 @@ namespace polysolve::linear
 
     // Analyze sparsity pattern
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
+    void EigenDirect<SparseSolver>::analyze_pattern(const Hessian &H, const int precond_num)
     {
+        auto &A = H.get<StiffnessMatrix>();
         m_Solver.analyzePattern(A);
     }
 
     // Factorize system matrix
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::factorize(const StiffnessMatrix &A)
+    void EigenDirect<SparseSolver>::factorize(const Hessian &H)
     {
+        auto &A = H.get<StiffnessMatrix>();
         m_Solver.factorize(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/EigenSolver.tpp
+++ b/src/polysolve/linear/EigenSolver.tpp
@@ -93,16 +93,17 @@ namespace polysolve::linear
 
     // Analyze sparsity pattern
     template <typename SparseSolver>
-    void EigenIterative<SparseSolver>::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
+    void EigenIterative<SparseSolver>::analyze_pattern(const Hessian &H, const int precond_num)
     {
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.analyzePattern(A);
     }
 
     // Factorize system matrix
     template <typename SparseSolver>
-    void EigenIterative<SparseSolver>::factorize(const StiffnessMatrix &A)
+    void EigenIterative<SparseSolver>::factorize(const Hessian &H)
     {
-        m_A = A;
+        m_A = H.as<StiffnessMatrix>();
         m_Solver.factorize(m_A);
     }
 
@@ -127,9 +128,9 @@ namespace polysolve::linear
     }
 
     template <typename DenseSolver>
-    void EigenDenseSolver<DenseSolver>::factorize(const StiffnessMatrix &A)
+    void EigenDenseSolver<DenseSolver>::factorize(const Hessian &A)
     {
-        factorize_dense(Eigen::MatrixXd(A));
+        factorize_dense(A.as<Eigen::MatrixXd>());
     }
 
     // Factorize system matrix

--- a/src/polysolve/linear/EigenSolver.tpp
+++ b/src/polysolve/linear/EigenSolver.tpp
@@ -35,17 +35,15 @@ namespace polysolve::linear
 
     // Analyze sparsity pattern
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::analyze_pattern(const Hessian &H, const int precond_num)
+    void EigenDirect<SparseSolver>::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
     {
-        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.analyzePattern(A);
     }
 
     // Factorize system matrix
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::factorize(const Hessian &H)
+    void EigenDirect<SparseSolver>::factorize(const StiffnessMatrix &A)
     {
-        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.factorize(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/EigenSolver.tpp
+++ b/src/polysolve/linear/EigenSolver.tpp
@@ -37,7 +37,7 @@ namespace polysolve::linear
     template <typename SparseSolver>
     void EigenDirect<SparseSolver>::analyze_pattern(const Hessian &H, const int precond_num)
     {
-        auto &A = H.get<StiffnessMatrix>();
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.analyzePattern(A);
     }
 
@@ -45,7 +45,7 @@ namespace polysolve::linear
     template <typename SparseSolver>
     void EigenDirect<SparseSolver>::factorize(const Hessian &H)
     {
-        auto &A = H.get<StiffnessMatrix>();
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.factorize(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/EigenSolver.tpp
+++ b/src/polysolve/linear/EigenSolver.tpp
@@ -35,15 +35,17 @@ namespace polysolve::linear
 
     // Analyze sparsity pattern
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
+    void EigenDirect<SparseSolver>::analyze_pattern(const Hessian &H, const int precond_num)
     {
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.analyzePattern(A);
     }
 
     // Factorize system matrix
     template <typename SparseSolver>
-    void EigenDirect<SparseSolver>::factorize(const StiffnessMatrix &A)
+    void EigenDirect<SparseSolver>::factorize(const Hessian &H)
     {
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.factorize(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/HypreSolver.cpp
+++ b/src/polysolve/linear/HypreSolver.cpp
@@ -82,8 +82,9 @@ namespace polysolve::linear
 
     ////////////////////////////////////////////////////////////////////////////////
 
-    void HypreSolver::factorize(const StiffnessMatrix &Ain)
+    void HypreSolver::factorize(const Hessian &H)
     {
+        auto &Ain = H.get<StiffnessMatrix>();
         assert(precond_num_ > 0);
 
         if (has_matrix_)

--- a/src/polysolve/linear/HypreSolver.cpp
+++ b/src/polysolve/linear/HypreSolver.cpp
@@ -84,7 +84,7 @@ namespace polysolve::linear
 
     void HypreSolver::factorize(const Hessian &H)
     {
-        auto &Ain = H.get<StiffnessMatrix>();
+        const auto &Ain = H.as<StiffnessMatrix>();
         assert(precond_num_ > 0);
 
         if (has_matrix_)

--- a/src/polysolve/linear/HypreSolver.hpp
+++ b/src/polysolve/linear/HypreSolver.hpp
@@ -42,10 +42,10 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override { precond_num_ = precond_num; }
+        virtual void analyze_pattern(const Hessian &H, const int precond_num) override { precond_num_ = precond_num; }
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &H) override;
 
         // Solve the linear system Ax = b
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/HypreSolver.hpp
+++ b/src/polysolve/linear/HypreSolver.hpp
@@ -41,6 +41,10 @@ namespace polysolve::linear
         // Retrieve memory information from Pardiso
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &H, const int precond_num) override { precond_num_ = precond_num; }
 

--- a/src/polysolve/linear/MASSolver.hpp
+++ b/src/polysolve/linear/MASSolver.hpp
@@ -51,6 +51,12 @@ namespace polysolve::linear
         // Retrieve information
         void get_info(json &params) const override;
 
+        // Analyze sparsity pattern
+        virtual void analyze_pattern(const Hessian &A, const int precond_num) override { analyze_pattern(A.as<StiffnessMatrix>(), precond_num); }
+
+        // Factorize system matrix
+        virtual void factorize(const Hessian &A) override { factorize(A.as<StiffnessMatrix>()); }
+
         // Analyze sparsity pattern. This is a no-op
         void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
 

--- a/src/polysolve/linear/Pardiso.cpp
+++ b/src/polysolve/linear/Pardiso.cpp
@@ -202,7 +202,7 @@ namespace polysolve::linear
 
     void Pardiso::analyze_pattern(const Hessian &H, const int precond_num)
     {
-        auto &A = H.get<StiffnessMatrix>();
+        const auto &A = H.as<StiffnessMatrix>();
         if (mtype == -1)
         {
             throw std::runtime_error("[Pardiso] mtype not set.");
@@ -263,7 +263,7 @@ namespace polysolve::linear
 
     void Pardiso::factorize(const Hessian &H)
     {
-        auto &A = H.get<StiffnessMatrix>();
+        const auto &A = H.as<StiffnessMatrix>();
         if (mtype == -1)
         {
             throw std::runtime_error("[Pardiso] mtype not set.");

--- a/src/polysolve/linear/Pardiso.cpp
+++ b/src/polysolve/linear/Pardiso.cpp
@@ -200,8 +200,9 @@ namespace polysolve::linear
 
     ////////////////////////////////////////////////////////////////////////////////
 
-    void Pardiso::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
+    void Pardiso::analyze_pattern(const Hessian &H, const int precond_num)
     {
+        auto &A = H.get<StiffnessMatrix>();
         if (mtype == -1)
         {
             throw std::runtime_error("[Pardiso] mtype not set.");
@@ -260,8 +261,9 @@ namespace polysolve::linear
 
     // -----------------------------------------------------------------------------
 
-    void Pardiso::factorize(const StiffnessMatrix &A)
+    void Pardiso::factorize(const Hessian &H)
     {
+        auto &A = H.get<StiffnessMatrix>();
         if (mtype == -1)
         {
             throw std::runtime_error("[Pardiso] mtype not set.");

--- a/src/polysolve/linear/Pardiso.hpp
+++ b/src/polysolve/linear/Pardiso.hpp
@@ -44,10 +44,10 @@ namespace polysolve::linear
         virtual void get_info(json &params) const override;
 
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override;
+        virtual void analyze_pattern(const Hessian &A, const int precond_num) override;
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &A) override;
 
         // Solve the linear system Ax = b
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/Pardiso.hpp
+++ b/src/polysolve/linear/Pardiso.hpp
@@ -43,6 +43,10 @@ namespace polysolve::linear
         // Retrieve memory information from Pardiso
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &A, const int precond_num) override;
 

--- a/src/polysolve/linear/SaddlePointSolver.cpp
+++ b/src/polysolve/linear/SaddlePointSolver.cpp
@@ -110,8 +110,9 @@ namespace polysolve::linear
 
     ////////////////////////////////////////////////////////////////////////////////
 
-    void SaddlePointSolver::factorize(const StiffnessMatrix &Ain)
+    void SaddlePointSolver::factorize(const Hessian &Ain_H)
     {
+        const StiffnessMatrix &Ain = Ain_H.as<StiffnessMatrix>();
         assert(precond_num_ > 0);
         Ain_ = Ain;
         // A = M.A(1:ablock-1, 1:ablock-1);

--- a/src/polysolve/linear/SaddlePointSolver.hpp
+++ b/src/polysolve/linear/SaddlePointSolver.hpp
@@ -33,11 +33,15 @@ namespace polysolve::linear
         // Retrieve memory information from Pardiso
         virtual void get_info(json &params) const override;
 
+        // Prevent hiding
+        using Solver::analyze_pattern;
+        using Solver::factorize;
+
         // Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) override { precond_num_ = precond_num; }
+        virtual void analyze_pattern(const Hessian &A, const int precond_num) override { precond_num_ = precond_num; }
 
         // Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) override;
+        virtual void factorize(const Hessian &A) override;
 
         // Solve the linear system Ax = b
         virtual void solve(const Ref<const VectorXd> b, Ref<VectorXd> x) override;

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -57,6 +57,9 @@ namespace polysolve::linear
 #ifdef POLYSOLVE_WITH_AMGCL
 #include "AMGCL.hpp"
 #endif
+#ifdef MESHFEM_WITH_CATAMARI
+#include "CatamariSolver.hpp"
+#endif
 #ifdef POLYSOLVE_WITH_CUSOLVER
 #include "CuSolverDN.cuh"
 #endif
@@ -416,6 +419,12 @@ namespace polysolve::linear
         {
             return std::make_unique<AMGCL>();
 #endif
+#ifdef MESHFEM_WITH_CATAMARI
+        }
+        else if (solver == "Catamari")
+        {
+            return std::make_unique<CatamariSolver>();
+#endif
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
             // Available only with Eigen 3.3.0 and newer
 #ifndef POLYSOLVE_LARGE_INDEX
@@ -544,6 +553,9 @@ namespace polysolve::linear
 #endif
 #ifdef POLYSOLVE_WITH_AMGCL
             "AMGCL",
+#endif
+#ifdef MESHFEM_WITH_CATAMARI
+            "Catamari",
 #endif
 #if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 #ifndef POLYSOLVE_LARGE_INDEX

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -26,13 +26,14 @@
 namespace polysolve::linear
 {
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const StiffnessMatrix &A, const int precond_num)
-    {
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const Hessian &H, const int precond_num) {
+        const StiffnessMatrix &A = H.as<StiffnessMatrix>();
         m_Solver.compute(A);
     }
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const StiffnessMatrix &A)
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const Hessian &H)
     {
+        const StiffnessMatrix &A = H.as<StiffnessMatrix>();
         m_Solver.compute(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -26,14 +26,12 @@
 namespace polysolve::linear
 {
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const Hessian &H, const int precond_num) {
-        const StiffnessMatrix &A = H.as<StiffnessMatrix>();
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const StiffnessMatrix &A, const int precond_num) {
         m_Solver.compute(A);
     }
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const Hessian &H)
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const StiffnessMatrix &A)
     {
-        const StiffnessMatrix &A = H.as<StiffnessMatrix>();
         m_Solver.compute(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/Solver.cpp
+++ b/src/polysolve/linear/Solver.cpp
@@ -26,12 +26,14 @@
 namespace polysolve::linear
 {
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const StiffnessMatrix &A, const int precond_num) {
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::analyze_pattern(const Hessian &H, const int precond_num) {
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.compute(A);
     }
     template <>
-    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const StiffnessMatrix &A)
+    void EigenDirect<Eigen::SPQR<StiffnessMatrix>>::factorize(const Hessian &H)
     {
+        const auto &A = H.as<StiffnessMatrix>();
         m_Solver.compute(A);
         if (m_Solver.info() == Eigen::NumericalIssue)
         {

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -106,10 +106,14 @@ namespace polysolve::linear
 
         /// The following two overloads are still needed by `SaddlePointSolver`,
         /// which operates on asymmetric matrices that are not Hessians.
+        /// They can also be helpful in avoiding a copy in use cases where
+        /// the user generates and the solver natively accepts a `StiffnessMatrix`.
         virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) { analyze_pattern(Hessian(A), precond_num); }
         virtual void factorize(const StiffnessMatrix &A) { factorize(Hessian(A)); }
 
         /// Analyze sparsity pattern of a dense matrix
+        /// Note: these `*_dense` methods are most likely obviated by the new
+        /// variant machinery...
         virtual void analyze_pattern_dense(const Eigen::MatrixXd &A, const int precond_num) {}
 
         /// Factorize system matrix of a dense matrix

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -96,13 +96,12 @@ namespace polysolve::linear
         virtual void analyze_pattern(const Hessian &A, const int precond_num) {}
 
         /// Factorize system matrix
-        virtual void factorize(const StiffnessMatrix &A) {}
-
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) {}
-
-        /// Factorize system matrix
         virtual void factorize(const Hessian &A) {}
 
+        /// The following two overloads are still needed by `SaddlePointSolver`,
+        /// which operates on asymmetric matrices that are not Hessians.
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) {}
+        virtual void factorize(const StiffnessMatrix &A) {}
 
         /// Analyze sparsity pattern of a dense matrix
         virtual void analyze_pattern_dense(const Eigen::MatrixXd &A, const int precond_num) {}

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -108,8 +108,8 @@ namespace polysolve::linear
         /// which operates on asymmetric matrices that are not Hessians.
         /// They can also be helpful in avoiding a copy in use cases where
         /// the user generates and the solver natively accepts a `StiffnessMatrix`.
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) { analyze_pattern(Hessian(A), precond_num); }
-        virtual void factorize(const StiffnessMatrix &A) { factorize(Hessian(A)); }
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) { analyze_pattern(Hessian::borrow(A), precond_num); }
+        virtual void factorize(const StiffnessMatrix &A) { factorize(Hessian::borrow(A)); }
 
         /// Analyze sparsity pattern of a dense matrix
         /// Note: these `*_dense` methods are most likely obviated by the new

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -93,10 +93,16 @@ namespace polysolve::linear
         virtual void get_info(json &params) const {};
 
         /// Analyze sparsity pattern
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) {}
+        virtual void analyze_pattern(const Hessian &A, const int precond_num) {}
 
         /// Factorize system matrix
         virtual void factorize(const StiffnessMatrix &A) {}
+
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) {}
+
+        /// Factorize system matrix
+        virtual void factorize(const Hessian &A) {}
+
 
         /// Analyze sparsity pattern of a dense matrix
         virtual void analyze_pattern_dense(const Eigen::MatrixXd &A, const int precond_num) {}

--- a/src/polysolve/linear/Solver.hpp
+++ b/src/polysolve/linear/Solver.hpp
@@ -92,6 +92,12 @@ namespace polysolve::linear
         /// Get info on the last solve step
         virtual void get_info(json &params) const {};
 
+        int last_analyzed_pattern_id() const { return last_analyzed_pattern_id_; }
+
+        void set_last_analyzed_pattern_id(const int pattern_id) { last_analyzed_pattern_id_ = pattern_id; }
+
+        void clear_last_analyzed_pattern_id() { last_analyzed_pattern_id_ = -1; }
+
         /// Analyze sparsity pattern
         virtual void analyze_pattern(const Hessian &A, const int precond_num) {}
 
@@ -100,8 +106,8 @@ namespace polysolve::linear
 
         /// The following two overloads are still needed by `SaddlePointSolver`,
         /// which operates on asymmetric matrices that are not Hessians.
-        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) {}
-        virtual void factorize(const StiffnessMatrix &A) {}
+        virtual void analyze_pattern(const StiffnessMatrix &A, const int precond_num) { analyze_pattern(Hessian(A), precond_num); }
+        virtual void factorize(const StiffnessMatrix &A) { factorize(Hessian(A)); }
 
         /// Analyze sparsity pattern of a dense matrix
         virtual void analyze_pattern_dense(const Eigen::MatrixXd &A, const int precond_num) {}
@@ -134,6 +140,9 @@ namespace polysolve::linear
 
         /// @brief Name of the solver type (for debugging purposes)
         virtual std::string name() const { return ""; }
+
+    private:
+        int last_analyzed_pattern_id_ = -1;
     };
 
 } // namespace polysolve::linear

--- a/src/polysolve/nonlinear/Problem.hpp
+++ b/src/polysolve/nonlinear/Problem.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <polysolve/Types.hpp>
+#include <MeshFEM/newton_optimizer/NewtonHessian.hh>
 
 #include "Criteria.hpp"
 #include "PostStepData.hpp"
@@ -60,6 +61,13 @@ namespace polysolve::nonlinear
         {
             throw std::runtime_error("Dense Hessian not implemented.");
         }
+
+        virtual NewtonHessian evalHessian(const TVector &x) { 
+            throw std::runtime_error("evalHessian not implemented.");
+        }
+
+        virtual size_t getSparsityPatternID() const { return -1; }
+
 
         /// @brief Compute the Hessian of the function at x.
         /// @param[in] x Degrees of freedom.

--- a/src/polysolve/nonlinear/Problem.hpp
+++ b/src/polysolve/nonlinear/Problem.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <polysolve/Types.hpp>
-#include <MeshFEM/newton_optimizer/NewtonHessian.hh>
 
 #include "Criteria.hpp"
 #include "PostStepData.hpp"
@@ -54,13 +53,13 @@ namespace polysolve::nonlinear
         /// @param[out] grad Gradient of the function at x.
         virtual void gradient(const TVector &x, TVector &grad) = 0;
 
-        /// @brief Compute the Hessian of the function at x.
-        /// @param[in] x Degrees of freedom.
-        /// @param[out] hessian Hessian of the function at x.
-        virtual void hessian(const TVector &x, TMatrix &hessian)
-        {
-            throw std::runtime_error("Dense Hessian not implemented.");
-        }
+        // /// @brief Compute the Hessian of the function at x.
+        // /// @param[in] x Degrees of freedom.
+        // /// @param[out] hessian Hessian of the function at x.
+        // virtual void hessian(const TVector &x, Hessian &hessian)
+        // {
+        //     throw std::runtime_error("Dense Hessian not implemented.");
+        // }
 
         virtual NewtonHessian evalHessian(const TVector &x) { 
             throw std::runtime_error("evalHessian not implemented.");
@@ -72,7 +71,7 @@ namespace polysolve::nonlinear
         /// @brief Compute the Hessian of the function at x.
         /// @param[in] x Degrees of freedom.
         /// @param[out] hessian Hessian of the function at x.
-        virtual void hessian(const TVector &x, THessian &hessian) = 0;
+        virtual void hessian(const TVector &x, Hessian &hessian) = 0;
 
         /// @brief Determine if the step from x0 to x1 is valid.
         /// @param x0 Starting point.

--- a/src/polysolve/nonlinear/Problem.hpp
+++ b/src/polysolve/nonlinear/Problem.hpp
@@ -53,20 +53,15 @@ namespace polysolve::nonlinear
         /// @param[out] grad Gradient of the function at x.
         virtual void gradient(const TVector &x, TVector &grad) = 0;
 
-        // /// @brief Compute the Hessian of the function at x.
-        // /// @param[in] x Degrees of freedom.
-        // /// @param[out] hessian Hessian of the function at x.
-        // virtual void hessian(const TVector &x, Hessian &hessian)
-        // {
-        //     throw std::runtime_error("Dense Hessian not implemented.");
-        // }
-
-        virtual NewtonHessian evalHessian(const TVector &x) { 
-            throw std::runtime_error("evalHessian not implemented.");
+        /// @brief Compute the Hessian of the function at x.
+        /// @param[in] x Degrees of freedom.
+        /// @param[out] hessian Hessian of the function at x.
+        virtual void hessian(const TVector &x, TMatrix &hessian)
+        {
+            throw std::runtime_error("Dense Hessian not implemented.");
         }
 
         virtual size_t getSparsityPatternID() const { return -1; }
-
 
         /// @brief Compute the Hessian of the function at x.
         /// @param[in] x Degrees of freedom.

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -512,7 +512,11 @@ namespace polysolve::nonlinear
             //                descent_strategy_name(), m_line_search->name(), rate, step);
 
             update_solver_info(energy);
-            objFunc.post_step(PostStepData(m_current.iterations, solver_info, x, grad));
+            
+            {
+                POLYSOLVE_SCOPED_STOPWATCH("Post_step", post_step, m_logger);
+                objFunc.post_step(PostStepData(m_current.iterations, solver_info, x, grad));
+            }
 
             if (objFunc.stop(x))
             {
@@ -579,6 +583,7 @@ namespace polysolve::nonlinear
         update_direction_time = 0;
         line_search_time = 0;
         constraint_set_update_time = 0;
+        post_step = 0;
         if (m_line_search)
             m_line_search->reset_times();
         for (auto &s : m_strategies)
@@ -596,17 +601,44 @@ namespace polysolve::nonlinear
 
         double per_iteration = m_current.iterations ? m_current.iterations : 1;
 
-        solver_info["total_time"] = total_time;
-        solver_info["time_obj_fun"] = obj_fun_time / per_iteration;
-        solver_info["time_grad"] = grad_time / per_iteration;
-        // Do not save update_direction_time as it is redundant with the strategies
-        solver_info["time_line_search"] = line_search_time / per_iteration;
-        solver_info["time_constraint_set_update"] = constraint_set_update_time / per_iteration;
+        // solver_info["total_time"] = total_time;
+        // solver_info["time_obj_fun"] = obj_fun_time / per_iteration;
+        // solver_info["time_grad"] = grad_time / per_iteration;
+        // // Do not save update_direction_time as it is redundant with the strategies
+        // solver_info["time_line_search"] = line_search_time / per_iteration;
+        // solver_info["time_constraint_set_update"] = constraint_set_update_time / per_iteration;
 
-        for (auto &s : m_strategies)
-            s->update_solver_info(solver_info, per_iteration);
+        
+        // for (auto &s : m_strategies)
+        //     s->update_solver_info(solver_info, per_iteration);
+        // if (m_line_search)
+        //     m_line_search->update_solver_info(solver_info, per_iteration);
+
+        solver_info["Newton iterations per time step::total_time"] = total_time;
+        solver_info["Newton iterations per time step::function_evaluation"] = obj_fun_time;
+        solver_info["Newton iterations per time step::gradient_evaluation"] = grad_time;
+        // Do not save update_direction_time as it is redundant with the strategies
+        solver_info["Newton iterations per time step::line_search"] = line_search_time;
+        solver_info["Newton iterations per time step::time_constraint_set_update"] = constraint_set_update_time;
+        solver_info["Newton iterations per time step::update_direction_time"] = update_direction_time;
+        solver_info["Newton iterations per time step::post_step"] = post_step;
+       
+        
+        std::vector<double> update_direction_times = {0.0, 0.0, 0.0, 0.0};
+        size_t numStrategies = size(m_strategies);
+        for (size_t i = 0; i < numStrategies; i++){
+            auto &s = m_strategies[i];
+            s->update_times(update_direction_times); 
+        }
+
+        solver_info["Newton iterations per time step::update_direction::hessian_assembly"] = update_direction_times[0];
+        solver_info["Newton iterations per time step::update_direction::linear_solve::symbolic_factorizer"] = update_direction_times[1];
+        solver_info["Newton iterations per time step::update_direction::linear_solve::numeric_factorizer"] = update_direction_times[2];
+        solver_info["Newton iterations per time step::update_direction::linear_solve::solve"] = update_direction_times[3];
+        
         if (m_line_search)
             m_line_search->update_solver_info(solver_info, per_iteration);
+
     }
 
     void Solver::log_times() const

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -392,9 +392,9 @@ namespace polysolve::nonlinear
             {
                 try
                 {
-                    THessian hessian;
+                    Hessian hessian;
                     objFunc.hessian(x, hessian);
-                    m_current.newtonDecrement = 0.5 * x.dot(hessian * x);
+                    m_current.newtonDecrement = 0.5 * x.dot(hessian.as<StiffnessMatrix>() * x);
                 }
                 catch (const std::runtime_error &e)
                 {

--- a/src/polysolve/nonlinear/Solver.cpp
+++ b/src/polysolve/nonlinear/Solver.cpp
@@ -512,11 +512,7 @@ namespace polysolve::nonlinear
             //                descent_strategy_name(), m_line_search->name(), rate, step);
 
             update_solver_info(energy);
-            
-            {
-                POLYSOLVE_SCOPED_STOPWATCH("Post_step", post_step, m_logger);
-                objFunc.post_step(PostStepData(m_current.iterations, solver_info, x, grad));
-            }
+            objFunc.post_step(PostStepData(m_current.iterations, solver_info, x, grad));
 
             if (objFunc.stop(x))
             {
@@ -583,7 +579,6 @@ namespace polysolve::nonlinear
         update_direction_time = 0;
         line_search_time = 0;
         constraint_set_update_time = 0;
-        post_step = 0;
         if (m_line_search)
             m_line_search->reset_times();
         for (auto &s : m_strategies)
@@ -601,44 +596,17 @@ namespace polysolve::nonlinear
 
         double per_iteration = m_current.iterations ? m_current.iterations : 1;
 
-        // solver_info["total_time"] = total_time;
-        // solver_info["time_obj_fun"] = obj_fun_time / per_iteration;
-        // solver_info["time_grad"] = grad_time / per_iteration;
-        // // Do not save update_direction_time as it is redundant with the strategies
-        // solver_info["time_line_search"] = line_search_time / per_iteration;
-        // solver_info["time_constraint_set_update"] = constraint_set_update_time / per_iteration;
-
-        
-        // for (auto &s : m_strategies)
-        //     s->update_solver_info(solver_info, per_iteration);
-        // if (m_line_search)
-        //     m_line_search->update_solver_info(solver_info, per_iteration);
-
-        solver_info["Newton iterations per time step::total_time"] = total_time;
-        solver_info["Newton iterations per time step::function_evaluation"] = obj_fun_time;
-        solver_info["Newton iterations per time step::gradient_evaluation"] = grad_time;
+        solver_info["total_time"] = total_time;
+        solver_info["time_obj_fun"] = obj_fun_time / per_iteration;
+        solver_info["time_grad"] = grad_time / per_iteration;
         // Do not save update_direction_time as it is redundant with the strategies
-        solver_info["Newton iterations per time step::line_search"] = line_search_time;
-        solver_info["Newton iterations per time step::time_constraint_set_update"] = constraint_set_update_time;
-        solver_info["Newton iterations per time step::update_direction_time"] = update_direction_time;
-        solver_info["Newton iterations per time step::post_step"] = post_step;
-       
-        
-        std::vector<double> update_direction_times = {0.0, 0.0, 0.0, 0.0};
-        size_t numStrategies = size(m_strategies);
-        for (size_t i = 0; i < numStrategies; i++){
-            auto &s = m_strategies[i];
-            s->update_times(update_direction_times); 
-        }
+        solver_info["time_line_search"] = line_search_time / per_iteration;
+        solver_info["time_constraint_set_update"] = constraint_set_update_time / per_iteration;
 
-        solver_info["Newton iterations per time step::update_direction::hessian_assembly"] = update_direction_times[0];
-        solver_info["Newton iterations per time step::update_direction::linear_solve::symbolic_factorizer"] = update_direction_times[1];
-        solver_info["Newton iterations per time step::update_direction::linear_solve::numeric_factorizer"] = update_direction_times[2];
-        solver_info["Newton iterations per time step::update_direction::linear_solve::solve"] = update_direction_times[3];
-        
+        for (auto &s : m_strategies)
+            s->update_solver_info(solver_info, per_iteration);
         if (m_line_search)
             m_line_search->update_solver_info(solver_info, per_iteration);
-
     }
 
     void Solver::log_times() const

--- a/src/polysolve/nonlinear/Solver.hpp
+++ b/src/polysolve/nonlinear/Solver.hpp
@@ -199,7 +199,6 @@ namespace polysolve::nonlinear
         double update_direction_time;
         double line_search_time;
         double constraint_set_update_time;
-        double post_step;
 
         // ====================================================================
         //                                 END

--- a/src/polysolve/nonlinear/Solver.hpp
+++ b/src/polysolve/nonlinear/Solver.hpp
@@ -199,6 +199,7 @@ namespace polysolve::nonlinear
         double update_direction_time;
         double line_search_time;
         double constraint_set_update_time;
+        double post_step;
 
         // ====================================================================
         //                                 END

--- a/src/polysolve/nonlinear/descent_strategies/DescentStrategy.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/DescentStrategy.hpp
@@ -34,7 +34,6 @@ namespace polysolve::nonlinear
         /// @param per_iteration Number of iterations (used to normalize timings)
         virtual void update_solver_info(json &solver_info, const double per_iteration) {}
         virtual void log_times() const {}
-        virtual void update_times(std::vector<double> &linear_times) {}
 
         virtual bool is_direction_descent() { return true; }
         virtual bool handle_error() { return false; }

--- a/src/polysolve/nonlinear/descent_strategies/DescentStrategy.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/DescentStrategy.hpp
@@ -34,6 +34,7 @@ namespace polysolve::nonlinear
         /// @param per_iteration Number of iterations (used to normalize timings)
         virtual void update_solver_info(json &solver_info, const double per_iteration) {}
         virtual void log_times() const {}
+        virtual void update_times(std::vector<double> &linear_times) {}
 
         virtual bool is_direction_descent() { return true; }
         virtual bool handle_error() { return false; }

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -175,23 +175,22 @@ namespace polysolve::nonlinear
                                               const TVector &grad,
                                               TVector &direction)
     {
-        polysolve::StiffnessMatrix hessian;
+        Hessian hessian(std::in_place_type<NewtonHessian>);
         {
             POLYSOLVE_SCOPED_STOPWATCH("assembly time", this->assembly_time, m_logger);
             compute_hessian(objFunc, x, hessian);
         }
-
         {
             // TODO: get the correct size
             if (objFunc.getSparsityPatternID() == -1)
             {
-                POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->inverting_time, m_logger);
+                POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->symbolic_factorizer_time, m_logger);
                 linear_solver->analyze_pattern(hessian, hessian.rows());
             }
 
             try
             {
-                POLYSOLVE_SCOPED_STOPWATCH("numeric factorize", this->inverting_time, m_logger);
+                POLYSOLVE_SCOPED_STOPWATCH("numeric factorize", this->numeric_factorizer_time, m_logger);
                 linear_solver->factorize(hessian);
             }
             catch (const std::runtime_error &err)
@@ -203,7 +202,7 @@ namespace polysolve::nonlinear
                 return std::nan("");
             }
             {
-                POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
+                POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->linear_solve_time, m_logger);
                 linear_solver->solve(-grad, direction); // H Δx = -g
             }
         }
@@ -222,15 +221,14 @@ namespace polysolve::nonlinear
                                              const TVector &grad,
                                              TVector &direction)
     {
-        Eigen::MatrixXd hessian;
-
+        Hessian hessian_v(std::in_place_type<Eigen::MatrixXd>);
         {
             POLYSOLVE_SCOPED_STOPWATCH("assembly time", this->assembly_time, m_logger);
-            compute_hessian(objFunc, x, hessian);
+            compute_hessian(objFunc, x, hessian_v);
         }
-
+        const Eigen::MatrixXd &hessian = hessian_v.get<Eigen::MatrixXd>();
         {
-            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
+            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->solve_time, m_logger);
 
             try
             {
@@ -260,8 +258,7 @@ namespace polysolve::nonlinear
 
     void Newton::compute_hessian(Problem &objFunc,
                                  const TVector &x,
-                                 polysolve::StiffnessMatrix &hessian)
-
+                                 Hessian &hessian)
     {
         objFunc.set_project_to_psd(false);
         objFunc.hessian(x, hessian);
@@ -269,8 +266,7 @@ namespace polysolve::nonlinear
 
     void ProjectedNewton::compute_hessian(Problem &objFunc,
                                           const TVector &x,
-                                          polysolve::StiffnessMatrix &hessian)
-
+                                          Hessian &hessian)
     {
         objFunc.set_project_to_psd(true);
         objFunc.hessian(x, hessian);
@@ -278,85 +274,31 @@ namespace polysolve::nonlinear
 
     void RegularizedNewton::compute_hessian(Problem &objFunc,
                                             const TVector &x,
-                                            polysolve::StiffnessMatrix &hessian)
-
-    {
-        if (x.size() != x_cache.size() || x != x_cache)
-        {
-            objFunc.set_project_to_psd(project_to_psd);
-            objFunc.hessian(x, hessian_cache);
-            x_cache = x;
-        }
-        hessian = hessian_cache;
-        if (reg_weight > 0)
-        {
-            hessian += reg_weight * sparse_identity(hessian.rows(), hessian.cols());
-        }
-    }
-
-    void Newton::compute_hessian(Problem &objFunc,
-                                 const TVector &x,
-                                 Eigen::MatrixXd &hessian)
-
-    {
-        objFunc.set_project_to_psd(false);
-        objFunc.hessian(x, hessian);
-    }
-
-    void ProjectedNewton::compute_hessian(Problem &objFunc,
-                                          const TVector &x,
-                                          Eigen::MatrixXd &hessian)
-
-    {
-        objFunc.set_project_to_psd(true);
-        objFunc.hessian(x, hessian);
-    }
-
-    void RegularizedNewton::compute_hessian(Problem &objFunc,
-                                            const TVector &x,
-                                            Eigen::MatrixXd &hessian)
-
+                                            Hessian &hessian)
     {
         objFunc.set_project_to_psd(project_to_psd);
         objFunc.hessian(x, hessian);
-        if (reg_weight > 0)
-        {
-            for (int k = 0; k < x.size(); k++)
-                hessian(k, k) += reg_weight;
-        }
-    }
 
-    void Newton::compute_hessian(Problem &objFunc,
-                                 const TVector &x,
-                                 NewtonHessian &hessian)
-
-    {
-        objFunc.set_project_to_psd(false);
-        hessian = objFunc.evalHessian(x);
-    }
-
-     void ProjectedNewton::compute_hessian(Problem &objFunc,
-                                          const TVector &x,
-                                          NewtonHessian &hessian)
-
-    {
-        objFunc.set_project_to_psd(true);
-        hessian = objFunc.evalHessian(x);
-    }
-
-    void RegularizedNewton::compute_hessian(Problem &objFunc,
-                                            const TVector &x,
-                                            NewtonHessian &hessian)
-
-    {
-        objFunc.set_project_to_psd(project_to_psd);
-        hessian = objFunc.evalHessian(x);
-        if (reg_weight > 0)
-        {
-            // Need to add reg_weight times Identity to the hessian.
-
-        
-        }
+        // std::visit([&](auto &h) {
+        //     using T = std::decay_t<decltype(h)>;
+        //     if constexpr (std::is_same_v<T, polysolve::StiffnessMatrix>) {
+        //         if (x.size() != x_cache.size() || x != x_cache) {
+        //             objFunc.hessian(x, hessian_cache);
+        //             x_cache = x;
+        //         }
+        //         h = hessian_cache;
+        //         if (reg_weight > 0)
+        //             h += reg_weight * sparse_identity(h.rows(), h.cols());
+        //     } else if constexpr (std::is_same_v<T, Eigen::MatrixXd>) {
+        //         objFunc.hessian(x, h);
+        //         if (reg_weight > 0)
+        //             for (int k = 0; k < x.size(); k++)
+        //                 h(k, k) += reg_weight;
+        //     } else if constexpr (std::is_same_v<T, NewtonHessian>) {
+        //         h = objFunc.evalHessian(x);
+        //         // TODO: add reg_weight * identity
+        //     }
+        // }, hessian);
     }
 
     // =======================================================================
@@ -381,6 +323,18 @@ namespace polysolve::nonlinear
     {
         assembly_time = 0;
         inverting_time = 0;
+        linear_solve_time = 0;
+        symbolic_factorizer_time = 0;
+        numeric_factorizer_time = 0;
+        solve_time = 0;
+    }
+
+     void Newton::update_times(std::vector<double> &linear_times)
+    {
+        linear_times[0] += assembly_time;
+        linear_times[1] += symbolic_factorizer_time;
+        linear_times[2] += numeric_factorizer_time;
+        linear_times[3] += is_sparse ? linear_solve_time : solve_time;
     }
 
     void Newton::log_times() const

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -176,20 +176,22 @@ namespace polysolve::nonlinear
                                               TVector &direction)
     {
         polysolve::StiffnessMatrix hessian;
-
         {
             POLYSOLVE_SCOPED_STOPWATCH("assembly time", this->assembly_time, m_logger);
             compute_hessian(objFunc, x, hessian);
         }
 
         {
-            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
-
             // TODO: get the correct size
-            linear_solver->analyze_pattern(hessian, hessian.rows());
+            if (objFunc.getSparsityPatternID() == -1)
+            {
+                POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->inverting_time, m_logger);
+                linear_solver->analyze_pattern(hessian, hessian.rows());
+            }
 
             try
             {
+                POLYSOLVE_SCOPED_STOPWATCH("numeric factorize", this->inverting_time, m_logger);
                 linear_solver->factorize(hessian);
             }
             catch (const std::runtime_error &err)
@@ -200,8 +202,10 @@ namespace polysolve::nonlinear
                 // Eigen::saveMarket(hessian, "problematic_hessian.mtx");
                 return std::nan("");
             }
-
-            linear_solver->solve(-grad, direction); // H Δx = -g
+            {
+                POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
+                linear_solver->solve(-grad, direction); // H Δx = -g
+            }
         }
 
         const double residual = objFunc.grad_norm(hessian * direction + grad, norm_type); // H Δx + g = 0
@@ -321,6 +325,40 @@ namespace polysolve::nonlinear
                 hessian(k, k) += reg_weight;
         }
     }
+
+    void Newton::compute_hessian(Problem &objFunc,
+                                 const TVector &x,
+                                 NewtonHessian &hessian)
+
+    {
+        objFunc.set_project_to_psd(false);
+        hessian = objFunc.evalHessian(x);
+    }
+
+     void ProjectedNewton::compute_hessian(Problem &objFunc,
+                                          const TVector &x,
+                                          NewtonHessian &hessian)
+
+    {
+        objFunc.set_project_to_psd(true);
+        hessian = objFunc.evalHessian(x);
+    }
+
+    void RegularizedNewton::compute_hessian(Problem &objFunc,
+                                            const TVector &x,
+                                            NewtonHessian &hessian)
+
+    {
+        objFunc.set_project_to_psd(project_to_psd);
+        hessian = objFunc.evalHessian(x);
+        if (reg_weight > 0)
+        {
+            // Need to add reg_weight times Identity to the hessian.
+
+        
+        }
+    }
+
     // =======================================================================
 
     bool RegularizedNewton::handle_error()

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -234,17 +234,17 @@ namespace polysolve::nonlinear
             compute_hessian(objFunc, x, hessian);
         }
         {
+            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
+
             int pattern_id = objFunc.getSparsityPatternID();
             if ((pattern_id == -1) || (pattern_id != linear_solver->last_analyzed_pattern_id()))
             {
-                POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->symbolic_factorizer_time, m_logger);
                 linear_solver->analyze_pattern(hessian, hessian.rows());
                 linear_solver->set_last_analyzed_pattern_id(pattern_id);
             }
 
             try
             {
-                POLYSOLVE_SCOPED_STOPWATCH("numeric factorize", this->numeric_factorizer_time, m_logger);
                 linear_solver->factorize(hessian);
             }
             catch (const std::runtime_error &err)
@@ -255,10 +255,7 @@ namespace polysolve::nonlinear
                 // Eigen::saveMarket(hessian, "problematic_hessian.mtx");
                 return std::nan("");
             }
-            {
-                POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->linear_solve_time, m_logger);
-                linear_solver->solve(-grad, direction); // H Δx = -g
-            }
+            linear_solver->solve(-grad, direction); // H Δx = -g
         }
 
         const double residual = objFunc.grad_norm(hessian * direction + grad, norm_type); // H Δx + g = 0
@@ -282,7 +279,7 @@ namespace polysolve::nonlinear
         }
         const Eigen::MatrixXd &hessian = hessian_v.as<Eigen::MatrixXd>();
         {
-            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->solve_time, m_logger);
+            POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->inverting_time, m_logger);
 
             try
             {
@@ -362,18 +359,6 @@ namespace polysolve::nonlinear
     {
         assembly_time = 0;
         inverting_time = 0;
-        linear_solve_time = 0;
-        symbolic_factorizer_time = 0;
-        numeric_factorizer_time = 0;
-        solve_time = 0;
-    }
-
-     void Newton::update_times(std::vector<double> &linear_times)
-    {
-        linear_times[0] += assembly_time;
-        linear_times[1] += symbolic_factorizer_time;
-        linear_times[2] += numeric_factorizer_time;
-        linear_times[3] += is_sparse ? linear_solve_time : solve_time;
     }
 
     void Newton::log_times() const

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -10,6 +10,21 @@
 
 namespace polysolve::nonlinear
 {
+    namespace
+    {
+        std::shared_ptr<polysolve::linear::Solver> create_linear_solver(
+            const bool sparse,
+            const json &linear_solver_params,
+            spdlog::logger &logger)
+        {
+            auto linear_solver = std::shared_ptr<polysolve::linear::Solver>(
+                polysolve::linear::Solver::create(linear_solver_params, logger));
+            if (linear_solver->is_dense() == sparse)
+                log_and_throw_error(logger, "Newton linear solver must be {}, instead got {}", sparse ? "sparse" : "dense", linear_solver->name());
+
+            return linear_solver;
+        }
+    } // namespace
 
     std::vector<std::shared_ptr<DescentStrategy>> Newton::create_solver(
         const bool sparse,
@@ -29,26 +44,28 @@ namespace polysolve::nonlinear
         reg_solver_params["RegularizedNewton"]["reg_weight_max"] = solver_params["Newton"]["reg_weight_max"];
         reg_solver_params["RegularizedNewton"]["reg_weight_inc"] = solver_params["Newton"]["reg_weight_inc"];
 
+        auto linear_solver = create_linear_solver(sparse, linear_solver_params, logger);
+
         std::vector<std::shared_ptr<DescentStrategy>> res;
         const bool force_psd_projection = solver_params["Newton"]["force_psd_projection"];
         if (!force_psd_projection)
-            res.push_back(std::make_unique<Newton>(
+            res.push_back(std::make_shared<Newton>(
                 sparse,
-                solver_params, linear_solver_params,
+                solver_params, linear_solver,
                 characteristic_length, logger, norm_type));
 
         const bool use_psd_projection = solver_params["Newton"]["use_psd_projection"];
         if (use_psd_projection)
-            res.push_back(std::make_unique<ProjectedNewton>(
+            res.push_back(std::make_shared<ProjectedNewton>(
                 sparse,
-                proj_solver_params, linear_solver_params,
+                proj_solver_params, linear_solver,
                 characteristic_length, logger, norm_type));
 
         const double reg_weight_min = solver_params["Newton"]["reg_weight_min"];
         if (reg_weight_min > 0)
-            res.push_back(std::make_unique<RegularizedNewton>(
+            res.push_back(std::make_shared<RegularizedNewton>(
                 sparse, solver_params["Newton"]["use_psd_projection_in_regularized"],
-                reg_solver_params, linear_solver_params,
+                reg_solver_params, linear_solver,
                 characteristic_length, logger, norm_type));
 
         if (res.empty())
@@ -60,17 +77,19 @@ namespace polysolve::nonlinear
     Newton::Newton(const bool sparse,
                    const double residual_tolerance,
                    const json &solver_params,
-                   const json &linear_solver_params,
+                   std::shared_ptr<polysolve::linear::Solver> linear_solver,
                    const double characteristic_length,
                    spdlog::logger &logger,
                    const NormType norm_type)
         : Superclass(solver_params, characteristic_length, logger),
-          is_sparse(sparse), characteristic_length(characteristic_length), residual_tolerance(residual_tolerance), norm_type(norm_type)
+          is_sparse(sparse), characteristic_length(characteristic_length), residual_tolerance(residual_tolerance), norm_type(norm_type),
+          linear_solver(std::move(linear_solver))
     {
-        linear_solver = polysolve::linear::Solver::create(linear_solver_params, logger);
+        if (this->linear_solver == nullptr)
+            log_and_throw_error(logger, "Newton linear solver must not be null");
 
-        if (linear_solver->is_dense() == sparse)
-            log_and_throw_error(logger, "Newton linear solver must be {}, instead got {}", sparse ? "sparse" : "dense", linear_solver->name());
+        if (this->linear_solver->is_dense() == sparse)
+            log_and_throw_error(logger, "Newton linear solver must be {}, instead got {}", sparse ? "sparse" : "dense", this->linear_solver->name());
 
         if (residual_tolerance <= 0)
             log_and_throw_error(logger, "Newton residual_tolerance must be > 0, instead got {}", residual_tolerance);
@@ -83,7 +102,18 @@ namespace polysolve::nonlinear
         const double characteristic_length,
         spdlog::logger &logger,
         const NormType norm_type)
-        : Newton(sparse, extract_param("Newton", "residual_tolerance", solver_params), solver_params, linear_solver_params, characteristic_length, logger, norm_type)
+        : Newton(sparse, solver_params, create_linear_solver(sparse, linear_solver_params, logger), characteristic_length, logger, norm_type)
+    {
+    }
+
+    Newton::Newton(
+        const bool sparse,
+        const json &solver_params,
+        std::shared_ptr<polysolve::linear::Solver> linear_solver,
+        const double characteristic_length,
+        spdlog::logger &logger,
+        const NormType norm_type)
+        : Newton(sparse, extract_param("Newton", "residual_tolerance", solver_params), solver_params, std::move(linear_solver), characteristic_length, logger, norm_type)
     {
     }
 
@@ -94,7 +124,18 @@ namespace polysolve::nonlinear
         const double characteristic_length,
         spdlog::logger &logger,
         const NormType norm_type)
-        : Superclass(sparse, extract_param("ProjectedNewton", "residual_tolerance", solver_params), solver_params, linear_solver_params, characteristic_length, logger, norm_type)
+        : ProjectedNewton(sparse, solver_params, create_linear_solver(sparse, linear_solver_params, logger), characteristic_length, logger, norm_type)
+    {
+    }
+
+    ProjectedNewton::ProjectedNewton(
+        const bool sparse,
+        const json &solver_params,
+        std::shared_ptr<polysolve::linear::Solver> linear_solver,
+        const double characteristic_length,
+        spdlog::logger &logger,
+        const NormType norm_type)
+        : Superclass(sparse, extract_param("ProjectedNewton", "residual_tolerance", solver_params), solver_params, std::move(linear_solver), characteristic_length, logger, norm_type)
     {
     }
 
@@ -106,7 +147,19 @@ namespace polysolve::nonlinear
         const double characteristic_length,
         spdlog::logger &logger,
         const NormType norm_type)
-        : Superclass(sparse, extract_param("RegularizedNewton", "residual_tolerance", solver_params), solver_params, linear_solver_params, characteristic_length, logger, norm_type),
+        : RegularizedNewton(sparse, project_to_psd, solver_params, create_linear_solver(sparse, linear_solver_params, logger), characteristic_length, logger, norm_type)
+    {
+    }
+
+    RegularizedNewton::RegularizedNewton(
+        const bool sparse,
+        const bool project_to_psd,
+        const json &solver_params,
+        std::shared_ptr<polysolve::linear::Solver> linear_solver,
+        const double characteristic_length,
+        spdlog::logger &logger,
+        const NormType norm_type)
+        : Superclass(sparse, extract_param("RegularizedNewton", "residual_tolerance", solver_params), solver_params, std::move(linear_solver), characteristic_length, logger, norm_type),
           project_to_psd(project_to_psd)
     {
         reg_weight_min = extract_param("RegularizedNewton", "reg_weight_min", solver_params);
@@ -182,11 +235,11 @@ namespace polysolve::nonlinear
         }
         {
             int pattern_id = objFunc.getSparsityPatternID();
-            if ((pattern_id == -1) || (pattern_id != last_analyzed_pattern_id))
+            if ((pattern_id == -1) || (pattern_id != linear_solver->last_analyzed_pattern_id()))
             {
                 POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->symbolic_factorizer_time, m_logger);
                 linear_solver->analyze_pattern(hessian, hessian.rows());
-                last_analyzed_pattern_id = pattern_id;
+                linear_solver->set_last_analyzed_pattern_id(pattern_id);
             }
 
             try

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -181,11 +181,12 @@ namespace polysolve::nonlinear
             compute_hessian(objFunc, x, hessian);
         }
         {
-            // TODO: get the correct size
-            if (objFunc.getSparsityPatternID() == -1)
+            int pattern_id = objFunc.getSparsityPatternID();
+            if ((pattern_id == -1) || (pattern_id != last_analyzed_pattern_id))
             {
                 POLYSOLVE_SCOPED_STOPWATCH("symbolic factorize", this->symbolic_factorizer_time, m_logger);
                 linear_solver->analyze_pattern(hessian, hessian.rows());
+                last_analyzed_pattern_id = pattern_id;
             }
 
             try
@@ -279,26 +280,11 @@ namespace polysolve::nonlinear
         objFunc.set_project_to_psd(project_to_psd);
         objFunc.hessian(x, hessian);
 
-        // std::visit([&](auto &h) {
-        //     using T = std::decay_t<decltype(h)>;
-        //     if constexpr (std::is_same_v<T, polysolve::StiffnessMatrix>) {
-        //         if (x.size() != x_cache.size() || x != x_cache) {
-        //             objFunc.hessian(x, hessian_cache);
-        //             x_cache = x;
-        //         }
-        //         h = hessian_cache;
-        //         if (reg_weight > 0)
-        //             h += reg_weight * sparse_identity(h.rows(), h.cols());
-        //     } else if constexpr (std::is_same_v<T, Eigen::MatrixXd>) {
-        //         objFunc.hessian(x, h);
-        //         if (reg_weight > 0)
-        //             for (int k = 0; k < x.size(); k++)
-        //                 h(k, k) += reg_weight;
-        //     } else if constexpr (std::is_same_v<T, NewtonHessian>) {
-        //         h = objFunc.evalHessian(x);
-        //         // TODO: add reg_weight * identity
-        //     }
-        // }, hessian);
+        if (hessian.is_native_type<polysolve::BCSCHessianWithFixedVars>())
+            hessian.get_mutable<polysolve::BCSCHessianWithFixedVars>().reg_weight = reg_weight;
+        else if (hessian.is_native_type<polysolve::StiffnessMatrix>())
+            hessian.get_mutable<polysolve::StiffnessMatrix>() += reg_weight * sparse_identity(hessian.rows(), hessian.cols());
+        else throw std::runtime_error("RegularizedNewton: unexpected Hessian type for regularization");
     }
 
     // =======================================================================

--- a/src/polysolve/nonlinear/descent_strategies/Newton.cpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.cpp
@@ -175,7 +175,7 @@ namespace polysolve::nonlinear
                                               const TVector &grad,
                                               TVector &direction)
     {
-        Hessian hessian(std::in_place_type<NewtonHessian>);
+        Hessian hessian;
         {
             POLYSOLVE_SCOPED_STOPWATCH("assembly time", this->assembly_time, m_logger);
             compute_hessian(objFunc, x, hessian);
@@ -221,12 +221,12 @@ namespace polysolve::nonlinear
                                              const TVector &grad,
                                              TVector &direction)
     {
-        Hessian hessian_v(std::in_place_type<Eigen::MatrixXd>);
+        Hessian hessian_v;
         {
             POLYSOLVE_SCOPED_STOPWATCH("assembly time", this->assembly_time, m_logger);
             compute_hessian(objFunc, x, hessian_v);
         }
-        const Eigen::MatrixXd &hessian = hessian_v.get<Eigen::MatrixXd>();
+        const Eigen::MatrixXd &hessian = hessian_v.as<Eigen::MatrixXd>();
         {
             POLYSOLVE_SCOPED_STOPWATCH("linear solve", this->solve_time, m_logger);
 

--- a/src/polysolve/nonlinear/descent_strategies/Newton.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.hpp
@@ -5,12 +5,14 @@
 
 #include <polysolve/linear/Solver.hpp>
 
+
 namespace polysolve::nonlinear
 {
     class Newton : public DescentStrategy
     {
     public:
         using Superclass = DescentStrategy;
+        // using HessianVariant = std::variant<polysolve::StiffnessMatrix, Eigen::MatrixXd, NewtonHessian>;
 
         static std::vector<std::shared_ptr<DescentStrategy>> create_solver(
             const bool sparse,
@@ -54,25 +56,24 @@ namespace polysolve::nonlinear
         double residual_tolerance;
         const NormType norm_type;
 
+        int last_analyzed_pattern_id = -1; // Cache the last analyzed sparsity pattern ID to avoid redundant symbolic factorizations
+
         std::unique_ptr<polysolve::linear::Solver> linear_solver; ///< Linear solver used to solve the linear system
 
+        // Benchmarking variables
         double assembly_time;
         double inverting_time;
+        double linear_solve_time;
+        double symbolic_factorizer_time;
+        double numeric_factorizer_time;
+        double solve_time;
 
     protected:
         std::string internal_name() const { return is_sparse ? "Sparse" : "Dense"; }
 
         virtual void compute_hessian(Problem &objFunc,
                                      const TVector &x,
-                                     polysolve::StiffnessMatrix &hessian);
-
-        virtual void compute_hessian(Problem &objFunc,
-                                     const TVector &x,
-                                     Eigen::MatrixXd &hessian);
-
-        virtual void compute_hessian(Problem &objFunc,
-                                     const TVector &x,
-                                     NewtonHessian &hessian);
+                                     Hessian &hessian);
 
 
     public:
@@ -80,6 +81,7 @@ namespace polysolve::nonlinear
 
         void reset(const int ndof) override;
         void update_solver_info(json &solver_info, const double per_iteration) override;
+        virtual void update_times(std::vector<double> &linear_times) override;
         void reset_times() override;
         void log_times() const override;
     };
@@ -101,15 +103,7 @@ namespace polysolve::nonlinear
     protected:
         void compute_hessian(Problem &objFunc,
                              const TVector &x,
-                             polysolve::StiffnessMatrix &hessian) override;
-
-        void compute_hessian(Problem &objFunc,
-                             const TVector &x,
-                             Eigen::MatrixXd &hessian) override;
-
-        void compute_hessian(Problem &objFunc,
-                                     const TVector &x,
-                                     NewtonHessian &hessian) override;
+                             Hessian &hessian) override;
     };
 
     class RegularizedNewton : public Newton
@@ -145,15 +139,7 @@ namespace polysolve::nonlinear
     protected:
         void compute_hessian(Problem &objFunc,
                              const TVector &x,
-                             polysolve::StiffnessMatrix &hessian) override;
-
-        void compute_hessian(Problem &objFunc,
-                             const TVector &x,
-                             Eigen::MatrixXd &hessian) override;
-
-        void compute_hessian(Problem &objFunc,
-                            const TVector &x,
-                            NewtonHessian &hessian) override;
+                             Hessian &hessian) override;
     };
 
 } // namespace polysolve::nonlinear

--- a/src/polysolve/nonlinear/descent_strategies/Newton.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.hpp
@@ -70,6 +70,11 @@ namespace polysolve::nonlinear
                                      const TVector &x,
                                      Eigen::MatrixXd &hessian);
 
+        virtual void compute_hessian(Problem &objFunc,
+                                     const TVector &x,
+                                     NewtonHessian &hessian);
+
+
     public:
         bool compute_update_direction(Problem &objFunc, const TVector &x, const TVector &grad, TVector &direction) override;
 
@@ -101,6 +106,10 @@ namespace polysolve::nonlinear
         void compute_hessian(Problem &objFunc,
                              const TVector &x,
                              Eigen::MatrixXd &hessian) override;
+
+        void compute_hessian(Problem &objFunc,
+                                     const TVector &x,
+                                     NewtonHessian &hessian) override;
     };
 
     class RegularizedNewton : public Newton
@@ -141,6 +150,10 @@ namespace polysolve::nonlinear
         void compute_hessian(Problem &objFunc,
                              const TVector &x,
                              Eigen::MatrixXd &hessian) override;
+
+        void compute_hessian(Problem &objFunc,
+                            const TVector &x,
+                            NewtonHessian &hessian) override;
     };
 
 } // namespace polysolve::nonlinear

--- a/src/polysolve/nonlinear/descent_strategies/Newton.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.hpp
@@ -12,7 +12,6 @@ namespace polysolve::nonlinear
     {
     public:
         using Superclass = DescentStrategy;
-        // using HessianVariant = std::variant<polysolve::StiffnessMatrix, Eigen::MatrixXd, NewtonHessian>;
 
         static std::vector<std::shared_ptr<DescentStrategy>> create_solver(
             const bool sparse,
@@ -26,7 +25,7 @@ namespace polysolve::nonlinear
         Newton(const bool sparse,
                const double residual_tolerance,
                const json &solver_params,
-               const json &linear_solver_params,
+               std::shared_ptr<polysolve::linear::Solver> linear_solver,
                const double characteristic_length,
                spdlog::logger &logger,
                const NormType norm_type);
@@ -35,6 +34,13 @@ namespace polysolve::nonlinear
         Newton(const bool sparse,
                const json &solver_params,
                const json &linear_solver_params,
+               const double characteristic_length,
+               spdlog::logger &logger,
+               const NormType norm_type);
+
+        Newton(const bool sparse,
+               const json &solver_params,
+               std::shared_ptr<polysolve::linear::Solver> linear_solver,
                const double characteristic_length,
                spdlog::logger &logger,
                const NormType norm_type);
@@ -56,9 +62,7 @@ namespace polysolve::nonlinear
         double residual_tolerance;
         const NormType norm_type;
 
-        int last_analyzed_pattern_id = -1; // Cache the last analyzed sparsity pattern ID to avoid redundant symbolic factorizations
-
-        std::unique_ptr<polysolve::linear::Solver> linear_solver; ///< Linear solver used to solve the linear system
+        std::shared_ptr<polysolve::linear::Solver> linear_solver; /// Linear solver used to solve the linear system. Note that this can now be shared across compatible `DescentStrategy` instances.
 
         // Benchmarking variables
         double assembly_time;
@@ -98,6 +102,13 @@ namespace polysolve::nonlinear
                         spdlog::logger &logger,
                         const NormType norm_type);
 
+        ProjectedNewton(const bool sparse,
+                        const json &solver_params,
+                        std::shared_ptr<polysolve::linear::Solver> linear_solver,
+                        const double characteristic_length,
+                        spdlog::logger &logger,
+                        const NormType norm_type);
+
         std::string name() const override { return internal_name() + "ProjectedNewton"; }
 
     protected:
@@ -114,6 +125,13 @@ namespace polysolve::nonlinear
         RegularizedNewton(const bool sparse, const bool project_to_psd,
                           const json &solver_params,
                           const json &linear_solver_params,
+                          const double characteristic_length,
+                          spdlog::logger &logger,
+                          const NormType norm_type);
+
+        RegularizedNewton(const bool sparse, const bool project_to_psd,
+                          const json &solver_params,
+                          std::shared_ptr<polysolve::linear::Solver> linear_solver,
                           const double characteristic_length,
                           spdlog::logger &logger,
                           const NormType norm_type);

--- a/src/polysolve/nonlinear/descent_strategies/Newton.hpp
+++ b/src/polysolve/nonlinear/descent_strategies/Newton.hpp
@@ -64,13 +64,8 @@ namespace polysolve::nonlinear
 
         std::shared_ptr<polysolve::linear::Solver> linear_solver; /// Linear solver used to solve the linear system. Note that this can now be shared across compatible `DescentStrategy` instances.
 
-        // Benchmarking variables
         double assembly_time;
         double inverting_time;
-        double linear_solve_time;
-        double symbolic_factorizer_time;
-        double numeric_factorizer_time;
-        double solve_time;
 
     protected:
         std::string internal_name() const { return is_sparse ? "Sparse" : "Dense"; }
@@ -85,7 +80,6 @@ namespace polysolve::nonlinear
 
         void reset(const int ndof) override;
         void update_solver_info(json &solver_info, const double per_iteration) override;
-        virtual void update_times(std::vector<double> &linear_times) override;
         void reset_times() override;
         void log_times() const override;
     };

--- a/tests/test_linear_solver.cpp
+++ b/tests/test_linear_solver.cpp
@@ -155,9 +155,6 @@ void run_all_tests(const HessianType &A) {
 
         solver->get_info(solver_info);
 
-        // std::cout << "Testing solver: " << s << std::endl;
-        // std::cout << "x norm: " << x.norm() << std::endl;
-        // std::cout << "b norm: " << b.norm() << std::endl;
         const double err = (A * x - b).norm();
         INFO("solver: " + s);
         REQUIRE(err < 1e-8);

--- a/tests/test_linear_solver.cpp
+++ b/tests/test_linear_solver.cpp
@@ -100,14 +100,9 @@ TEST_CASE("multi-solver", "[solver]")
     REQUIRE(err < 1e-8);
 }
 
-TEST_CASE("all", "[solver]")
-{
-    const std::string path = POLYFEM_DATA_DIR;
-    Eigen::SparseMatrix<double> A;
-    const bool ok = loadMarket(A, path + "/A_2.mat");
-    REQUIRE(ok);
+template<class HessianType>
+void run_all_tests(const HessianType &A) {
     json solver_info;
-    Eigen::MatrixXd A_dense(A);
 
     auto solvers = Solver::available_solvers();
     for (const auto &s : solvers)
@@ -141,8 +136,12 @@ TEST_CASE("all", "[solver]")
 
         if (solver->is_dense())
         {
-            solver->analyze_pattern_dense(A, A.rows());
-            solver->factorize_dense(A);
+            // The clunky `static_cast` below is to ensure our variant type's
+            // `explicit` cast-to-dense operator is used.
+            // Simply doing `Eigen::MatrixXd(A)` confuses the Eigen overloads.
+            const auto &A_dense = static_cast<const Eigen::MatrixXd &>(A);
+            solver->analyze_pattern_dense(A_dense, A_dense.rows());
+            solver->factorize_dense(A_dense);
         }
         else
         {
@@ -156,11 +155,29 @@ TEST_CASE("all", "[solver]")
 
         solver->get_info(solver_info);
 
-        // std::cout<<"Solver error: "<<x<<std::endl;
+        // std::cout << "Testing solver: " << s << std::endl;
+        // std::cout << "x norm: " << x.norm() << std::endl;
+        // std::cout << "b norm: " << b.norm() << std::endl;
         const double err = (A * x - b).norm();
         INFO("solver: " + s);
         REQUIRE(err < 1e-8);
     }
+}
+
+TEST_CASE("all", "[solver]")
+{
+    const std::string path = POLYFEM_DATA_DIR;
+    Eigen::SparseMatrix<double> A;
+    const bool ok = loadMarket(A, path + "/A_2.mat");
+    REQUIRE(ok);
+    run_all_tests(A);
+
+    // Also test the Hessian variant type.
+    Hessian H(A);
+    run_all_tests(H);
+
+    H.switch_to_native_type<BCSCHessianWithFixedVars>();
+    run_all_tests(H);
 }
 
 TEST_CASE("eigen_params", "[solver]")

--- a/tests/test_nonlinear_solver.cpp
+++ b/tests/test_nonlinear_solver.cpp
@@ -62,9 +62,9 @@ public:
     {
         gradv = wrap(x).getGradient();
     }
-    void hessian(const TVector &x, THessian &hessian) override
+    void hessian(const TVector &x, Hessian &hessian) override
     {
-        hessian = wrap(x).getHessian().sparseView();
+        hessian.emplace<THessian>() = wrap(x).getHessian().sparseView();
     }
     void hessian(const TVector &x, Eigen::MatrixXd &hessian) override
     {
@@ -91,11 +91,11 @@ public:
         gradv(1) = 2 * (x(1) - 3);
         gradv(2) = 2 * (x(2) - 1);
     }
-    void hessian(const TVector &x, THessian &hessian) override
+    void hessian(const TVector &x, Hessian &hessian) override
     {
-        hessian.resize(3, 3);
-        hessian = sparse_identity(hessian.rows(), hessian.cols());
-        hessian *= 2;
+        auto &H = hessian.emplace<THessian>(3, 3);
+        H = sparse_identity(H.rows(), H.cols());
+        H *= 2;
     }
     void hessian(const TVector &x, Eigen::MatrixXd &hessian) override
     {
@@ -250,7 +250,10 @@ public:
         gradv.setZero(x.size());
         gradv(0) = 1;
     }
-    void hessian(const TVector &x, THessian &hessian) override {}
+    void hessian(const TVector &x, Hessian &hessian) override
+    {
+        hessian.emplace<THessian>(x.size(), x.size());
+    }
 
 private:
     const double upper_bound_;


### PR DESCRIPTION
Integrate BlockCatamari solver and add support for BlockCSCHessian. Also support sharing linear solvers across descent strategies to avoid unnecessary symbolic factorization work.

The various supported symmetric matrix types are managed by the new `Hessian` variant class, which facilitates the conversions needed when the `Problem` and `Solver` work in different formats.